### PR TITLE
fix: deliver recording events to event entity and improve call-button UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ The integration exposes native switch and button entities for easy dashboard con
 - **Answer Button** (`button.phone_line_answer`): Press this button to answer an active incoming call.
 - **Hang Up Button** (`button.phone_line_hangup`): Press this button to end the current call or decline an incoming call.
 
+Each button exposes a `can_press` attribute that reflects whether the action applies in the current call state (`answer` → only while a call is ringing in; `hangup` → whenever any call is active). Use it to hide the buttons when they are not actionable:
+
+```yaml
+type: conditional
+conditions:
+  - condition: state
+    entity: button.phone_line_answer
+    attribute: can_press
+    state: true
+card:
+  type: button
+  entity: button.phone_line_answer
+  name: Answer
+```
+
 ---
 
 ## Events & Event Entity

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -480,6 +480,12 @@ async def async_register_services(hass: HomeAssistant) -> None:
             # Fallback to the first loaded entry
             loaded_entries = [e for e in entries if e.state.value == "loaded"]
             if loaded_entries:
+                if len(loaded_entries) > 1:
+                    LOGGER.warning(
+                        "SIP service called without a target; defaulting to account '%s'. "
+                        "Specify a target entity/device to control a specific account.",
+                        loaded_entries[0].runtime_data["config"].username,
+                    )
                 matched_entries.append((loaded_entries[0].entry_id, loaded_entries[0].runtime_data))
 
         return matched_entries
@@ -659,6 +665,12 @@ async def async_register_services(hass: HomeAssistant) -> None:
                 EVENT_SIP_RECORDING_STARTED,
                 {"sip_account": data["config"].username, "recording_file": target_file},
             )
+            async_dispatcher_send(
+                hass,
+                f"{DOMAIN}_event_{entry_id}",
+                EVENT_SIP_RECORDING_STARTED,
+                {"recording_file": target_file},
+            )
 
     async def handle_stop_recording(call: ServiceCall) -> None:
         targets = await get_client_entries(call)
@@ -674,6 +686,12 @@ async def async_register_services(hass: HomeAssistant) -> None:
                 hass.bus.async_fire(
                     EVENT_SIP_RECORDING_STOPPED,
                     {"sip_account": data["config"].username},
+                )
+                async_dispatcher_send(
+                    hass,
+                    f"{DOMAIN}_event_{entry_id}",
+                    EVENT_SIP_RECORDING_STOPPED,
+                    None,
                 )
 
     async def handle_start_assist(call: ServiceCall) -> None:

--- a/custom_components/sip/button.py
+++ b/custom_components/sip/button.py
@@ -5,11 +5,13 @@ from typing import Any
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import DOMAIN
 from .helpers import build_device_info
-from .sip_client.sip_client import SipClient
+from .sip_client.sip_client import SipClient, SipState
 
 
 async def async_setup_entry(
@@ -25,42 +27,80 @@ async def async_setup_entry(
     ])
 
 
-class SipAnswerButton(ButtonEntity):
-    """Button to answer an incoming SIP call."""
+class SipCallButton(ButtonEntity):
+    """Base button that tracks call state so dashboards can hide it when idle."""
 
     _attr_has_entity_name = True
-    _attr_icon = "mdi:phone"
 
     def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
-        """Initialize the answer button."""
+        """Initialize the button."""
         self.entry = entry
         self.entry_data = entry_data
         self._client: SipClient = entry_data["client"]
         self._config = entry_data["config"]
-        self._attr_unique_id = f"{entry.entry_id}_answer"
-        self._attr_translation_key = "answer"
         self._attr_device_info = build_device_info(entry, self._config)
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to state updates so ``can_press`` stays current."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_state_update_{self.entry.entry_id}",
+                self._update_callback,
+            )
+        )
+
+    @callback
+    def _update_callback(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def _can_press(self) -> bool:
+        """Whether pressing the button does something in the current state."""
+        raise NotImplementedError
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose whether the action applies now for conditional cards/automations."""
+        return {"can_press": self._can_press}
+
+
+class SipAnswerButton(SipCallButton):
+    """Button to answer an incoming SIP call."""
+
+    _attr_icon = "mdi:phone"
+    _attr_translation_key = "answer"
+
+    def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
+        """Initialize the answer button."""
+        super().__init__(entry, entry_data)
+        self._attr_unique_id = f"{entry.entry_id}_answer"
+
+    @property
+    def _can_press(self) -> bool:
+        """Answering only applies while a call is ringing in."""
+        return self.entry_data.get("state") == SipState.INCOMING
 
     async def async_press(self) -> None:
         """Press the button to answer."""
         self._client.answer()
 
 
-class SipHangupButton(ButtonEntity):
+class SipHangupButton(SipCallButton):
     """Button to hang up the current SIP call."""
 
-    _attr_has_entity_name = True
     _attr_icon = "mdi:phone-hangup"
+    _attr_translation_key = "hangup"
 
     def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
         """Initialize the hangup button."""
-        self.entry = entry
-        self.entry_data = entry_data
-        self._client: SipClient = entry_data["client"]
-        self._config = entry_data["config"]
+        super().__init__(entry, entry_data)
         self._attr_unique_id = f"{entry.entry_id}_hangup"
-        self._attr_translation_key = "hangup"
-        self._attr_device_info = build_device_info(entry, self._config)
+
+    @property
+    def _can_press(self) -> bool:
+        """Hanging up applies whenever any call leg is active."""
+        return self.entry_data.get("state") not in (None, SipState.IDLE, SipState.REGISTERED)
 
     async def async_press(self) -> None:
         """Press the button to hang up."""

--- a/custom_components/sip/event.py
+++ b/custom_components/sip/event.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .helpers import build_device_info
 from .const import (
     DOMAIN,
     EVENT_SIP_CALL_CONNECTED,
@@ -55,14 +56,8 @@ class SipTelephonyEventEntity(EventEntity):
         self._entry_id = config_entry.entry_id
         self._attr_unique_id = f"{config_entry.entry_id}_telephony_events"
 
-        # Expose device info so the entity is grouped under the unified SIP device
-        username = entry_data["config"].username
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, config_entry.entry_id)},
-            "name": f"SIP Client ({username})",
-            "manufacturer": "hass-sip",
-            "model": "SIP Client Extension",
-        }
+        # Group under the unified SIP device shared by all platform entities.
+        self._attr_device_info = build_device_info(config_entry, entry_data["config"])
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks when added to hass."""


### PR DESCRIPTION
- Dispatch sip_recording_started/stopped to the event entity (were only fired on the bus, so the recording_started/recording_stopped event types never triggered)
- Unify event entity device_info via build_device_info so it groups under the same SIP device with consistent metadata
- Warn when a SIP service is called without a target and more than one account is loaded, instead of silently using the first one
- Expose a can_press attribute on the answer/hangup buttons (live state via dispatcher) so dashboards can hide them when not actionable
- Document the can_press conditional-card pattern in the README