### PR TITLE
fix: show event type in logbook and add event entity icon

### DIFF
--- a/custom_components/sip/event.py
+++ b/custom_components/sip/event.py
@@ -39,6 +39,7 @@ class SipTelephonyEventEntity(EventEntity):
 
     _attr_has_entity_name = True
     _attr_translation_key = "telephony"
+    _attr_icon = "mdi:phone-log"
     _attr_event_types = [
         "incoming",
         "connected",

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "dependencies": ["ffmpeg", "tts"],
   "after_dependencies": ["assist_pipeline", "stt"],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/custom_components/sip/strings.json
+++ b/custom_components/sip/strings.json
@@ -62,15 +62,19 @@
     "event": {
       "telephony": {
         "name": "Call Events",
-        "state": {
-          "incoming": "Incoming Call",
-          "connected": "Call Connected",
-          "playback_done": "Playback Finished",
-          "dtmf": "DTMF Keypress",
-          "ended": "Call Ended",
-          "recording_started": "Recording Started",
-          "recording_stopped": "Recording Stopped",
-          "registered": "Registered"
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "incoming": "Incoming Call",
+              "connected": "Call Connected",
+              "playback_done": "Playback Finished",
+              "dtmf": "DTMF Keypress",
+              "ended": "Call Ended",
+              "recording_started": "Recording Started",
+              "recording_stopped": "Recording Stopped",
+              "registered": "Registered"
+            }
+          }
         }
       }
     }

--- a/custom_components/sip/translations/en.json
+++ b/custom_components/sip/translations/en.json
@@ -62,15 +62,19 @@
     "event": {
       "telephony": {
         "name": "Call Events",
-        "state": {
-          "incoming": "Incoming Call",
-          "connected": "Call Connected",
-          "playback_done": "Playback Finished",
-          "dtmf": "DTMF Keypress",
-          "ended": "Call Ended",
-          "recording_started": "Recording Started",
-          "recording_stopped": "Recording Stopped",
-          "registered": "Registered"
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "incoming": "Incoming Call",
+              "connected": "Call Connected",
+              "playback_done": "Playback Finished",
+              "dtmf": "DTMF Keypress",
+              "ended": "Call Ended",
+              "recording_started": "Recording Started",
+              "recording_stopped": "Recording Stopped",
+              "registered": "Registered"
+            }
+          }
         }
       }
     }

--- a/custom_components/sip/translations/ko.json
+++ b/custom_components/sip/translations/ko.json
@@ -62,15 +62,19 @@
     "event": {
       "telephony": {
         "name": "통화 이벤트",
-        "state": {
-          "incoming": "수신 통화",
-          "connected": "통화 연결됨",
-          "playback_done": "안내 재생 완료",
-          "dtmf": "DTMF 키 입력",
-          "ended": "통화 종료됨",
-          "recording_started": "녹음 시작됨",
-          "recording_stopped": "녹음 중지됨",
-          "registered": "등록됨"
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "incoming": "수신 통화",
+              "connected": "통화 연결됨",
+              "playback_done": "안내 재생 완료",
+              "dtmf": "DTMF 키 입력",
+              "ended": "통화 종료됨",
+              "recording_started": "녹음 시작됨",
+              "recording_stopped": "녹음 중지됨",
+              "registered": "등록됨"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- Move event type names from the entity `state` translation to `state_attributes.event_type.state`, where Home Assistant looks them up for the logbook and more-info dialog. The entity state is a timestamp, so the old `state` block was never used and the logbook only showed a generic "triggered" message.
- Add mdi:phone-log icon to the telephony event entity
- Bump version to 1.0.4