### PR TITLE
feat: readable SIP events in the logbook

### DIFF
--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import async_extract_config_entry_ids
 
@@ -39,6 +40,13 @@ from .const import (
 )
 from .helpers import get_ffmpeg_bin
 from .ivr import IvrSession
+
+
+def _sip_device_id(hass: HomeAssistant, entry_id: str) -> str | None:
+    """Return the device registry id for a SIP config entry, if created yet."""
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, entry_id)})
+    return device.id if device else None
+
 from .sip_client.audio import FfmpegAudioSource
 from .sip_client.sip_client import SipCallbacks, SipClient, SipConfig, SipState
 
@@ -163,6 +171,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "sip_account": sip_config.username,
             "server": sip_config.server,
         }
+        # Associate the event with the SIP device so it shows in the device logbook.
+        device_id = _sip_device_id(hass, entry.entry_id)
+        if device_id:
+            data["device_id"] = device_id
         if extra_data:
             data.update(extra_data)
         # event_type constants already carry the "sip_" prefix.
@@ -661,10 +673,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
             recorder = WavRecorderSink(target_file)
             client.set_sink(recorder)
             data["recorder"] = recorder
-            hass.bus.async_fire(
-                EVENT_SIP_RECORDING_STARTED,
-                {"sip_account": data["config"].username, "recording_file": target_file},
-            )
+            rec_data = {"sip_account": data["config"].username, "recording_file": target_file}
+            device_id = _sip_device_id(hass, entry_id)
+            if device_id:
+                rec_data["device_id"] = device_id
+            hass.bus.async_fire(EVENT_SIP_RECORDING_STARTED, rec_data)
             async_dispatcher_send(
                 hass,
                 f"{DOMAIN}_event_{entry_id}",
@@ -683,10 +696,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
                 client.set_sink(NullSink())
                 data.pop("recorder")
-                hass.bus.async_fire(
-                    EVENT_SIP_RECORDING_STOPPED,
-                    {"sip_account": data["config"].username},
-                )
+                stop_data = {"sip_account": data["config"].username}
+                device_id = _sip_device_id(hass, entry_id)
+                if device_id:
+                    stop_data["device_id"] = device_id
+                hass.bus.async_fire(EVENT_SIP_RECORDING_STOPPED, stop_data)
                 async_dispatcher_send(
                     hass,
                     f"{DOMAIN}_event_{entry_id}",

--- a/custom_components/sip/logbook.py
+++ b/custom_components/sip/logbook.py
@@ -1,0 +1,85 @@
+"""Logbook descriptions for SIP Client events.
+
+Event entities only ever render a generic "detected an event" line in the
+logbook, so we describe the integration's bus events here to produce readable
+messages (and attach the device id so they show in the device's logbook tab).
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from homeassistant.components.logbook import (
+    LOGBOOK_ENTRY_MESSAGE,
+    LOGBOOK_ENTRY_NAME,
+)
+from homeassistant.core import Event, HomeAssistant, callback
+
+from .const import (
+    DOMAIN,
+    EVENT_SIP_CALL_CONNECTED,
+    EVENT_SIP_CALL_ENDED,
+    EVENT_SIP_DTMF_DIGIT,
+    EVENT_SIP_INCOMING_CALL,
+    EVENT_SIP_PLAYBACK_DONE,
+    EVENT_SIP_RECORDING_STARTED,
+    EVENT_SIP_RECORDING_STOPPED,
+    EVENT_SIP_REGISTERED,
+)
+
+
+@callback
+def async_describe_events(
+    hass: HomeAssistant,
+    async_describe_event: Callable[[str, str, Callable[[Event], dict[str, str]]], None],
+) -> None:
+    """Describe SIP bus events for the logbook."""
+
+    def _name(data: dict) -> str:
+        account = data.get("sip_account")
+        return f"SIP ({account})" if account else "SIP"
+
+    @callback
+    def describe_incoming(event: Event) -> dict[str, str]:
+        data = event.data
+        who = data.get("caller_name") or data.get("caller") or "unknown"
+        return {LOGBOOK_ENTRY_NAME: _name(data), LOGBOOK_ENTRY_MESSAGE: f"incoming call from {who}"}
+
+    @callback
+    def describe_connected(event: Event) -> dict[str, str]:
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: "call connected"}
+
+    @callback
+    def describe_ended(event: Event) -> dict[str, str]:
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: "call ended"}
+
+    @callback
+    def describe_dtmf(event: Event) -> dict[str, str]:
+        digit = event.data.get("digit", "")
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: f"DTMF keypress {digit}".strip()}
+
+    @callback
+    def describe_playback_done(event: Event) -> dict[str, str]:
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: "playback finished"}
+
+    @callback
+    def describe_recording_started(event: Event) -> dict[str, str]:
+        target = event.data.get("recording_file")
+        message = f"recording started ({target})" if target else "recording started"
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: message}
+
+    @callback
+    def describe_recording_stopped(event: Event) -> dict[str, str]:
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: "recording stopped"}
+
+    @callback
+    def describe_registered(event: Event) -> dict[str, str]:
+        return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: "registered"}
+
+    async_describe_event(DOMAIN, EVENT_SIP_INCOMING_CALL, describe_incoming)
+    async_describe_event(DOMAIN, EVENT_SIP_CALL_CONNECTED, describe_connected)
+    async_describe_event(DOMAIN, EVENT_SIP_CALL_ENDED, describe_ended)
+    async_describe_event(DOMAIN, EVENT_SIP_DTMF_DIGIT, describe_dtmf)
+    async_describe_event(DOMAIN, EVENT_SIP_PLAYBACK_DONE, describe_playback_done)
+    async_describe_event(DOMAIN, EVENT_SIP_RECORDING_STARTED, describe_recording_started)
+    async_describe_event(DOMAIN, EVENT_SIP_RECORDING_STOPPED, describe_recording_stopped)
+    async_describe_event(DOMAIN, EVENT_SIP_REGISTERED, describe_registered)

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "dependencies": ["ffmpeg", "tts"],
   "after_dependencies": ["assist_pipeline", "stt"],
-  "version": "1.0.5"
+  "version": "1.0.6"
 }


### PR DESCRIPTION
Event entities only render a generic "detected an event" line in the logbook. Add a logbook platform that describes the integration's bus events (incoming/connected/ended/dtmf/playback/recording/registered) with human-readable messages, and attach the SIP device id to the fired events so the entries appear in the device's logbook tab.

- Add custom_components/sip/logbook.py with async_describe_events
- Include device_id in fire_sip_event and the recording service events
- Bump version to 1.0.6