### PR TITLE
feat: translate registration status and last call sensor states

### DIFF
--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "dependencies": ["ffmpeg", "tts"],
   "after_dependencies": ["assist_pipeline", "stt"],
-  "version": "1.0.5"
+  "version": "1.0.7"
 }

--- a/custom_components/sip/sensor.py
+++ b/custom_components/sip/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -36,6 +36,8 @@ class SipRegistrationSensor(SensorEntity):
 
     _attr_icon = "mdi:phone-check"
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["registered", "registering", "unregistered"]
 
     def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
         """Initialize the registration sensor."""
@@ -88,6 +90,8 @@ class SipLastCallSensor(SensorEntity):
 
     _attr_icon = "mdi:phone"
     _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["none", "incoming", "outgoing"]
 
     def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
         """Initialize the last call sensor."""

--- a/custom_components/sip/strings.json
+++ b/custom_components/sip/strings.json
@@ -27,10 +27,20 @@
   "entity": {
     "sensor": {
       "registration_status": {
-        "name": "Registration Status"
+        "name": "Registration Status",
+        "state": {
+          "registered": "Registered",
+          "registering": "Registering",
+          "unregistered": "Unregistered"
+        }
       },
       "last_call": {
-        "name": "Last Call"
+        "name": "Last Call",
+        "state": {
+          "none": "None",
+          "incoming": "Incoming",
+          "outgoing": "Outgoing"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/sip/translations/en.json
+++ b/custom_components/sip/translations/en.json
@@ -27,10 +27,20 @@
   "entity": {
     "sensor": {
       "registration_status": {
-        "name": "Registration Status"
+        "name": "Registration Status",
+        "state": {
+          "registered": "Registered",
+          "registering": "Registering",
+          "unregistered": "Unregistered"
+        }
       },
       "last_call": {
-        "name": "Last Call"
+        "name": "Last Call",
+        "state": {
+          "none": "None",
+          "incoming": "Incoming",
+          "outgoing": "Outgoing"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/sip/translations/ko.json
+++ b/custom_components/sip/translations/ko.json
@@ -27,10 +27,20 @@
   "entity": {
     "sensor": {
       "registration_status": {
-        "name": "등록 상태"
+        "name": "등록 상태",
+        "state": {
+          "registered": "등록됨",
+          "registering": "등록 중",
+          "unregistered": "등록 안 됨"
+        }
       },
       "last_call": {
-        "name": "최근 통화"
+        "name": "최근 통화",
+        "state": {
+          "none": "없음",
+          "incoming": "수신",
+          "outgoing": "발신"
+        }
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
Mark both sensors as ENUM device class with explicit options so Home Assistant translates their state values, and add EN/KO state strings:

- registration_status: registered / registering / unregistered
- last_call: none / incoming / outgoing

Bump version to 1.0.7