### PR TITLE
refactor: remove redundant global auto-answer switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The integration exposes native switch and button entities for easy dashboard con
 
 ### 1. Switches
 - **Do Not Disturb Switch** (`switch.phone_line_dnd`): Turn this ON to automatically reject all incoming calls with a `486 Busy Here` SIP response.
-- **Auto-Answer Switch** (`switch.phone_line_auto_answer`): Turn this ON to globally auto-answer all incoming calls immediately.
 
 ### 2. Buttons
 - **Answer Button** (`button.phone_line_answer`): Press this button to answer an active incoming call.
@@ -350,12 +349,13 @@ If mapped, the `last_call` Friendly Name sensor will display the contact name in
 
 ## Intercom & Auto-Answer Mode
 
-The integration can automatically answer incoming calls (useful for intercoms and doorbells). It triggers in three ways:
-1. **Global Toggle**: The Auto-Answer switch entity (`switch.phone_line_auto_answer`) is turned ON.
-2. **SIP Headers**: The incoming call includes standard auto-answer headers like `Call-Info: ...; answer-after=0` or `Alert-Info: Ring Answer`.
-3. **Contacts Configuration**: The incoming caller ID matches an extension marked with `"auto_answer": true` in `sip_contacts.json`.
+The integration can automatically answer specific incoming calls (useful for intercoms and doorbells). It triggers in two ways:
+1. **SIP Headers**: The incoming call includes standard auto-answer headers like `Call-Info: ...; answer-after=0` or `Alert-Info: Ring Answer`.
+2. **Contacts Configuration**: The incoming caller ID matches an extension marked with `"auto_answer": true` in `sip_contacts.json`.
 
-When triggered, the integration answers immediately, opens a two-way audio channel, and bypasses the ringing phase.
+When triggered, the integration answers immediately, opens the audio channel, and bypasses the ringing phase. Auto-answer only opens the channel — pair it with `sip.start_assist`, a TTS `message`, or `sip.start_recording` to actually send or capture audio.
+
+> To answer arbitrary calls under your own conditions, trigger an automation on the `sip_incoming_call` event and call `sip.answer` (optionally with a `message` or `menu`) instead.
 
 ---
 

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -208,10 +208,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.runtime_data["contacts"] = contacts_data
         hass.async_add_executor_job(reload_contacts_bg)
 
-        caller_name, contact_auto_answer = get_contact_info_from_cache(
+        caller_name, auto_answer = get_contact_info_from_cache(
             entry.runtime_data.get("contacts", {}), caller
         )
-        auto_answer = contact_auto_answer or getattr(client, "auto_answer", False)
         entry.runtime_data["last_caller"] = caller_name
         entry.runtime_data["call_number"] = caller
 

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "dependencies": ["ffmpeg", "tts"],
   "after_dependencies": ["assist_pipeline", "stt"],
-  "version": "1.0.6"
+  "version": "1.0.7"
 }

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -140,7 +140,6 @@ class SipClient:
         self._invite_retx_handle: asyncio.TimerHandle | None = None
         self._invite_retx_count = 0
         self.dnd = False
-        self.auto_answer = False
         self.auto_answer_checker: Callable[[str], bool] | None = None
 
     # ------------------------------------------------------------------
@@ -694,10 +693,6 @@ class SipClient:
                     auto_answer = self.auto_answer_checker(caller)
                 except Exception:
                     pass
-
-            # Also check global auto-answer toggle
-            if not auto_answer and self.auto_answer:
-                auto_answer = True
 
             if auto_answer:
                 _LOGGER.info("Auto-answering incoming call from %s (intercom)", caller)

--- a/custom_components/sip/strings.json
+++ b/custom_components/sip/strings.json
@@ -51,9 +51,6 @@
     "switch": {
       "dnd": {
         "name": "Do Not Disturb"
-      },
-      "auto_answer": {
-        "name": "Auto-Answer"
       }
     },
     "button": {

--- a/custom_components/sip/switch.py
+++ b/custom_components/sip/switch.py
@@ -19,10 +19,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up SIP Client switch from a config entry."""
     entry_data = entry.runtime_data
-    async_add_entities([
-        SipDndSwitch(entry, entry_data),
-        SipAutoAnswerSwitch(entry, entry_data),
-    ])
+    async_add_entities([SipDndSwitch(entry, entry_data)])
 
 
 class SipDndSwitch(SwitchEntity):
@@ -58,40 +55,4 @@ class SipDndSwitch(SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn DND off."""
         self._client.dnd = False
-        self.async_write_ha_state()
-
-
-class SipAutoAnswerSwitch(SwitchEntity):
-    """Representation of an Auto-Answer switch for the SIP client."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
-        """Initialize the Auto-Answer switch."""
-        self.entry = entry
-        self.entry_data = entry_data
-        self._client: SipClient = entry_data["client"]
-        self._config = entry_data["config"]
-        self._attr_unique_id = f"{entry.entry_id}_auto_answer"
-        self._attr_translation_key = "auto_answer"
-        self._attr_device_info = build_device_info(entry, self._config)
-
-    @property
-    def icon(self) -> str:
-        """Auto-Answer on -> phone-ring-outline; Auto-Answer off -> phone-cancel-outline."""
-        return "mdi:phone-ring" if self._client.auto_answer else "mdi:phone-off"
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if Auto-Answer is on."""
-        return self._client.auto_answer
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn Auto-Answer on."""
-        self._client.auto_answer = True
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn Auto-Answer off."""
-        self._client.auto_answer = False
         self.async_write_ha_state()

--- a/custom_components/sip/translations/en.json
+++ b/custom_components/sip/translations/en.json
@@ -51,9 +51,6 @@
     "switch": {
       "dnd": {
         "name": "Do Not Disturb"
-      },
-      "auto_answer": {
-        "name": "Auto-Answer"
       }
     },
     "button": {

--- a/custom_components/sip/translations/ko.json
+++ b/custom_components/sip/translations/ko.json
@@ -51,9 +51,6 @@
     "switch": {
       "dnd": {
         "name": "방해 금지"
-      },
-      "auto_answer": {
-        "name": "자동 응답"
       }
     },
     "button": {


### PR DESCRIPTION
The global auto-answer toggle added little value: any useful follow-up (TTS, Assist, recording) requires an automation anyway, and that automation can simply call sip.answer. Worse, leaving the toggle on races with such automations - the call is already answered, so a later sip.answer (with a message/menu) is ignored and nothing is spoken.

Contact-based and SIP-header auto-answer remain for true intercom and doorbell use.

- Remove SipAutoAnswerSwitch and the SipClient.auto_answer attribute
- Drop the global toggle check in the incoming-call handler
- Remove the auto_answer switch translations (en/ko/strings)
- Update README switch list and Intercom section
- Bump version to 1.0.7