### PR TITLE
fix(sip_client): address remaining Unifi Talk compatibility issues

### DIFF
--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -520,6 +520,18 @@ class SipClient:
         if not self._outbound:
             return
 
+        try:
+            cseq_num = int(m.header("CSeq").split()[0])
+        except (ValueError, IndexError):
+            cseq_num = 0
+
+        if cseq_num != self._d_cseq:
+            # Ignore responses for old transactions, but re-ACK final failures (>=300)
+            # to stop server retransmissions.
+            if 300 <= m.status_code < 700:
+                self._send_raw(self._build_ack(m))
+            return
+
         # Any response means the INVITE was received: stop retransmitting it.
         self._cancel_invite_retx()
 
@@ -571,13 +583,17 @@ class SipClient:
                 self._d_remote_target = contact_uri
             self._apply_remote_sdp(sm.parse_sdp(m.body))
             self._send_raw(self._build_ack(m))
-            self._loop.create_task(self._start_media())
+
+            async def _start_and_play():
+                await self._start_media()
+                if self._pending_source is not None:
+                    self.play_source(self._pending_source)
+                    self._pending_source = None
+
+            self._loop.create_task(_start_and_play())
             self._set_state(SipState.IN_CALL)
             _LOGGER.info("Call connected")
             self._emit("on_call_connected")
-            if self._pending_source is not None:
-                self.play_source(self._pending_source)
-                self._pending_source = None
             return
 
         # >= 300 final failure
@@ -603,6 +619,11 @@ class SipClient:
         self._remote_rtp_port = sdp.audio_port
         self._chosen_pt = _choose_payload(sdp)
         self._remote_dtmf_pt = sdp.telephone_event_pt
+
+        # Update RTP session with negotiated values
+        self.rtp.payload_type = self._chosen_pt
+        if self._remote_dtmf_pt >= 0:
+            self.rtp.dtmf_pt = self._remote_dtmf_pt
 
     # -- inbound requests ----------------------------------------------
     @staticmethod

--- a/custom_components/sip/sip_client/sip_message.py
+++ b/custom_components/sip/sip_client/sip_message.py
@@ -36,6 +36,26 @@ class SdpInfo:
     telephone_event_pt: int = -1
 
 
+# Compact header mapping (RFC 3261 Section 7.3.3)
+_COMPACT_HEADERS = {
+    "a": "accept-contact",
+    "b": "referred-by",
+    "c": "content-type",
+    "e": "content-encoding",
+    "f": "from",
+    "i": "call-id",
+    "k": "supported",
+    "l": "content-length",
+    "m": "contact",
+    "o": "event",
+    "r": "refer-to",
+    "s": "subject",
+    "t": "to",
+    "u": "allow-events",
+    "v": "via",
+}
+
+
 def parse_sip_message(raw: str) -> SipMessage:
     msg = SipMessage()
     header_end = raw.find("\r\n\r\n")
@@ -70,6 +90,7 @@ def parse_sip_message(raw: str) -> SipMessage:
         if colon == -1:
             continue
         name = line[:colon].strip().lower()
+        name = _COMPACT_HEADERS.get(name, name)
         value = line[colon + 1:].strip()
         # Keep the first occurrence (topmost Via, etc.).
         if name not in msg.headers:


### PR DESCRIPTION
Add follow-up fixes from StoneMonarch's fork that were missing from PR #18:

1. _handle_invite_response(): filter incoming INVITE responses by CSeq Ignore late 401/407 or 180 Ringing responses from previous transactions. Without this, late 407 responses from the initial unauthenticated INVITE would cause the client to abort the active call transaction.

2. _handle_invite_response(): sequential RTP startup and source playback Start RTP transport and await completion before starting pending audio source playback to prevent early audio packets from being discarded while the RTP socket is not yet bound.

3. sip_message: add support for compact headers (RFC 3261 Section 7.3.3) Allows parsing compact form headers like 'm' (Contact), 'f' (From), etc., which Unifi Talk/proxies can send.

4. Update RTP session with negotiated payload type and DTMF PT.