### PR TITLE
fix: honor register expiration during setup and handle SIP 423

### DIFF
--- a/custom_components/sip/config_flow.py
+++ b/custom_components/sip/config_flow.py
@@ -69,7 +69,11 @@ async def async_validate_sip_registration(
         password=user_input[CONF_PASSWORD],
         domain=user_input.get(CONF_DOMAIN, ""),
         caller_id=user_input.get(CONF_CALLER_ID, ""),
-        register_expiration=10,  # short expiration for test
+        # Use the configured expiration — a hardcoded short value (e.g. 10s)
+        # triggers SIP 423 Interval Too Brief on registrars with Min-Expires.
+        register_expiration=user_input.get(
+            CONF_REGISTER_EXPIRATION, DEFAULT_REGISTER_EXPIRATION
+        ),
         local_rtp_port=user_input.get(CONF_LOCAL_RTP_PORT, 7078),
     )
 

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -17,5 +17,5 @@
     "assist_pipeline",
     "stt"
   ],
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -270,6 +270,18 @@ class SipClient:
     def _contact_uri(self) -> str:
         return f"<sip:{self.config.username}@{self._local_ip}:{self._local_port}>"
 
+    @staticmethod
+    def _parse_min_expires(m: sm.SipMessage) -> int | None:
+        """Return Min-Expires from a 423 response, or None if missing/invalid."""
+        raw = m.header("Min-Expires")
+        if not raw:
+            return None
+        try:
+            value = int(raw.strip().split(";")[0].strip())
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
     def _build_register(self) -> str:
         cfg = self.config
         aor = f"sip:{cfg.username}@{cfg.domain}"
@@ -355,6 +367,31 @@ class SipClient:
         if m.status_code in (401, 407) and not self._register_auth_tried:
             self._register_auth_tried = True
             self._send_raw(self._authorized_register(m))
+            return
+        if m.status_code == 423:
+            # RFC 3261 §10.2.8 / §21.4.17: retry with Expires >= Min-Expires.
+            min_expires = self._parse_min_expires(m)
+            if min_expires is not None and min_expires > self.config.register_expiration:
+                _LOGGER.info(
+                    "REGISTER 423 Interval Too Brief; raising Expires from %s to %s",
+                    self.config.register_expiration,
+                    min_expires,
+                )
+                self.config.register_expiration = min_expires
+                self._do_register()
+                return
+            _LOGGER.warning(
+                "REGISTER failed: 423 Interval Too Brief (Min-Expires=%s, current=%s)",
+                min_expires,
+                self.config.register_expiration,
+            )
+            self.registered = False
+            self._reg_attempts = 0
+            self._emit(
+                "on_register_failed",
+                f"423 Interval Too Brief (Min-Expires={min_expires})",
+            )
+            self._schedule_register(10)
             return
         if 200 <= m.status_code < 300:
             was = self.registered


### PR DESCRIPTION
## Summary
- Config flow validation no longer hardcodes `Expires: 10` for the setup REGISTER; it uses the user-configured Registration Expiration (default 300).
- SIP client now handles `423 Interval Too Brief` by reading `Min-Expires` and retrying REGISTER with that value (RFC 3261).

This fixes setup failures against registrars whose minimum registration interval is higher than 10 seconds (e.g. Min-Expires 90), where changing the UI expiration previously had no effect.

## Test plan
- [ ] Add the SIP Client integration against a registrar with Min-Expires ≥ 90 and Registration Expiration = 300; setup should succeed.
- [ ] Confirm setup still fails clearly for wrong credentials (401/403).
- [ ] Optionally set Expiration below Min-Expires and verify logs show a 423 retry that raises Expires and then registers.
- [ ] After successful setup, confirm the registration status sensor shows registered and periodic re-REGISTER continues.


Made with [Cursor](https://cursor.com)