### PR TITLE
fix: recognize DTMF from SIP INFO and marker-less RFC 2833 packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Sends DTMF digits to the active SIP call.
 - `entity_id` *(Required)*: The target SIP media player entity.
 - `digits` *(Required)*: DTMF string to send (e.g., `123#`).
 
+> **Inbound DTMF:** digits pressed by the remote party are accepted both as RFC 2833 / RFC 4733 telephone-event packets and as SIP INFO (`application/dtmf-relay`), which is what many ATA/VoIP adapters send. **In-band DTMF (audio tones) is not detected** — set your ATA or PBX to RFC 2833 or SIP INFO if key presses are not recognised.
+
 ### `sip.start_recording`
 Starts recording call audio to a local WAV file.
 - `entity_id` *(Required)*: The target SIP media player entity.

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -17,5 +17,5 @@
     "assist_pipeline",
     "stt"
   ],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -80,6 +80,12 @@ class RtpSession:
         self._dtmf_timestamp = 0
         self._dtmf_end_packets = 0
 
+        # RX de-duplication: a telephone-event is repeated across many packets
+        # that all share one RTP timestamp, so the timestamp identifies the
+        # keypress. -1 means "no event seen yet".
+        self._rx_dtmf_timestamp = -1
+        self._rx_dtmf_pt_warned = False
+
         self.on_audio: Callable[[bytes], None] | None = None
         self.on_dtmf: Callable[[str], None] | None = None
 
@@ -111,6 +117,7 @@ class RtpSession:
         self._tx_buffer.clear()
         self._dtmf_queue.clear()
         self._dtmf_active = False
+        self._rx_dtmf_timestamp = -1
         self._sender_task = self._loop.create_task(self._sender())
         _LOGGER.info(
             "RTP started on port %s (pt=%s, dtmf_pt=%s)",
@@ -118,6 +125,11 @@ class RtpSession:
             self.payload_type,
             self.dtmf_pt,
         )
+        if self.dtmf_pt < 0:
+            _LOGGER.warning(
+                "Remote did not negotiate telephone-event (RFC 2833); inbound DTMF "
+                "will only work if the device sends it via SIP INFO"
+            )
         return True
 
     async def stop(self) -> None:
@@ -134,6 +146,7 @@ class RtpSession:
         self._tx_buffer.clear()
         self._dtmf_queue.clear()
         self._dtmf_active = False
+        self._rx_dtmf_timestamp = -1
 
     # -- TX -------------------------------------------------------------
     def push_tx_audio(self, pcm_le: bytes) -> None:
@@ -251,20 +264,41 @@ class RtpSession:
         if len(data) <= header_len:
             return
 
-        if self.dtmf_pt >= 0 and pt == self.dtmf_pt:
-            if marker and self.on_dtmf is not None:
-                event = data[header_len]
-                if event <= 9:
-                    c = chr(ord("0") + event)
-                elif event == 10:
-                    c = "*"
-                elif event == 11:
-                    c = "#"
-                elif event <= 15:
-                    c = chr(ord("A") + (event - 12))
-                else:
-                    c = "?"
-                self.on_dtmf(c)
+        payload_len = len(data) - header_len
+        is_dtmf = pt == self.dtmf_pt if self.dtmf_pt >= 0 else False
+        if not is_dtmf and 96 <= pt <= 127 and payload_len == 4:
+            # Some ATAs send RFC 2833 without ever offering telephone-event in
+            # their SDP (or on a different dynamic PT than negotiated). A 4-byte
+            # payload on a dynamic PT is the telephone-event shape, so accept it
+            # rather than dropping the keypress.
+            if not self._rx_dtmf_pt_warned:
+                self._rx_dtmf_pt_warned = True
+                _LOGGER.info(
+                    "Accepting inbound DTMF on unnegotiated payload type %s", pt
+                )
+            is_dtmf = True
+
+        if is_dtmf:
+            # Not every device sets the marker bit on the first packet of an
+            # event, so key off the RTP timestamp instead: all packets of one
+            # keypress repeat the same timestamp. The marker bit, when present,
+            # still forces a new event (two identical digits back to back).
+            timestamp = int.from_bytes(data[4:8], "big")
+            if marker or timestamp != self._rx_dtmf_timestamp:
+                self._rx_dtmf_timestamp = timestamp
+                if self.on_dtmf is not None:
+                    event = data[header_len]
+                    if event <= 9:
+                        c = chr(ord("0") + event)
+                    elif event == 10:
+                        c = "*"
+                    elif event == 11:
+                        c = "#"
+                    elif event <= 15:
+                        c = chr(ord("A") + (event - 12))
+                    else:
+                        c = "?"
+                    self.on_dtmf(c)
             return
 
         if pt not in (0, 8):

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -68,6 +68,52 @@ def _choose_payload(sdp: sm.SdpInfo) -> int:
     return 0
 
 
+_INFO_DTMF_TYPES = ("application/dtmf-relay", "application/dtmf", "audio/telephone-event")
+
+
+def _dtmf_from_token(token: str) -> str | None:
+    """Map a DTMF signal token (``1``, ``10``, ``*``, ``#``, ``A``…) to a character."""
+    token = token.strip()
+    if not token:
+        return None
+    if len(token) == 1 and (token.isdigit() or token in "*#ABCD"):
+        return token.upper()
+    # Numeric event codes (RFC 4733): 10 -> '*', 11 -> '#', 12..15 -> A..D
+    if token.isdigit():
+        event = int(token)
+        if event <= 9:
+            return str(event)
+        if event == 10:
+            return "*"
+        if event == 11:
+            return "#"
+        if event <= 15:
+            return chr(ord("A") + (event - 12))
+    return None
+
+
+def _parse_info_dtmf(content_type: str, body: str) -> str | None:
+    """Extract a DTMF digit from a SIP INFO body.
+
+    Handles the ``Signal=1`` / ``d=1`` key-value form used by most ATAs and
+    gateways, as well as a body that is just the bare digit.
+    """
+    if content_type and not any(t in content_type.lower() for t in _INFO_DTMF_TYPES):
+        return None
+    if not body:
+        return None
+
+    for line in body.splitlines():
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        if key.strip().lower() in ("signal", "d", "dtmf"):
+            return _dtmf_from_token(value)
+
+    # No key/value pair: some devices send just the digit as the whole body.
+    return _dtmf_from_token(body)
+
+
 def _angle_uri(value: str) -> str:
     lt = value.find("<")
     gt = value.find(">")
@@ -837,6 +883,16 @@ class SipClient:
                     self._build_response(self._incoming_invite, 487, "Request Terminated", False)
                 )
                 self._end_call()
+            return
+
+        if method == "INFO":
+            # Many ATAs / gateways signal DTMF out-of-band via SIP INFO instead
+            # of RFC 2833 telephone-event packets.
+            self._send_raw(self._build_response(m, 200, "OK", False))
+            digit = _parse_info_dtmf(m.header("Content-Type"), m.body)
+            if digit is not None:
+                _LOGGER.debug("DTMF '%s' received via SIP INFO", digit)
+                self._on_rx_dtmf(digit)
             return
 
         # OPTIONS / unknown in-dialog request: acknowledge.

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -18,6 +18,34 @@ import g711  # noqa: E402
 import sip_auth  # noqa: E402
 import sip_message as sm  # noqa: E402
 
+# rtp_session / sip_client use relative imports, so expose the directory as a
+# throwaway package to load them without Home Assistant.
+import asyncio  # noqa: E402
+import importlib.util  # noqa: E402
+import types  # noqa: E402
+
+_PKG = "_sipcore"
+_pkg_mod = types.ModuleType(_PKG)
+_pkg_mod.__path__ = [os.path.abspath(_SIP)]
+sys.modules[_PKG] = _pkg_mod
+
+
+def _load_pkg_module(name):
+    spec = importlib.util.spec_from_file_location(
+        f"{_PKG}.{name}", os.path.join(os.path.abspath(_SIP), f"{name}.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"{_PKG}.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rtp_session = _load_pkg_module("rtp_session")
+try:
+    sip_client = _load_pkg_module("sip_client")
+except AttributeError:  # enum.StrEnum needs Python 3.11+ (CI runs 3.12+)
+    sip_client = None
+
 
 # ---------------------------------------------------------------- g711
 def test_g711_silence_constants():
@@ -122,6 +150,105 @@ def test_digest_response_legacy_no_qop():
     r1 = sip_auth.digest_response("u", "p", "r", "REGISTER", "sip:x", "n", "", "", "")
     r2 = sip_auth.digest_response("u", "p", "r", "REGISTER", "sip:x", "n", "", "", "")
     assert r1 == r2 and len(r1) == 32
+
+
+# ------------------------------------------------------- SIP INFO DTMF
+def test_info_dtmf_signal_forms():
+    if sip_client is None:
+        return
+    p = sip_client._parse_info_dtmf
+    assert p("application/dtmf-relay", "Signal=1\r\nDuration=160") == "1"
+    assert p("application/dtmf-relay", "signal=#") == "#"
+    assert p("application/dtmf-relay", "d=7") == "7"
+    assert p("application/dtmf", "5") == "5"
+
+
+def test_info_dtmf_numeric_event_codes():
+    if sip_client is None:
+        return
+    # RFC 4733 event numbers, as sent by some gateways.
+    p = sip_client._parse_info_dtmf
+    assert p("application/dtmf-relay", "Signal=10") == "*"
+    assert p("application/dtmf-relay", "Signal=11") == "#"
+    assert p("application/dtmf-relay", "Signal=12") == "A"
+
+
+def test_info_dtmf_ignores_other_content():
+    if sip_client is None:
+        return
+    p = sip_client._parse_info_dtmf
+    assert p("application/sdp", "Signal=1") is None
+    assert p("application/dtmf-relay", "") is None
+    assert p("application/dtmf-relay", "Duration=160") is None
+
+
+# ------------------------------------------------------- RFC 2833 RX
+def _te_packet(pt, marker, timestamp, event, seq=1):
+    """Build one telephone-event RTP packet."""
+    b1 = (0x80 if marker else 0) | pt
+    return bytes([0x80, b1]) + struct.pack("!HII", seq, timestamp, 0x1234) + bytes(
+        [event, 0x0A, 0x00, 0xA0]
+    )
+
+
+def _collect_dtmf(packets, dtmf_pt=101):
+    async def run():
+        session = rtp_session.RtpSession()
+        session.dtmf_pt = dtmf_pt
+        got = []
+        session.on_dtmf = got.append
+        for pkt in packets:
+            session._receive_impl(pkt)
+        return got
+
+    return asyncio.run(run())
+
+
+def test_rfc2833_rx_without_marker_bit():
+    # Some ATAs never set the marker bit; one keypress must still fire once.
+    got = _collect_dtmf([_te_packet(101, False, 1000, 1) for _ in range(5)])
+    assert got == ["1"]
+
+
+def test_rfc2833_rx_deduplicates_by_timestamp():
+    packets = [_te_packet(101, False, 1000, 1) for _ in range(3)]
+    packets += [_te_packet(101, False, 2000, 2) for _ in range(3)]
+    assert _collect_dtmf(packets) == ["1", "2"]
+
+
+def test_rfc2833_rx_marker_forces_new_event():
+    # Same digit twice in a row shares no timestamp gap; marker separates them.
+    packets = [_te_packet(101, True, 700, 3), _te_packet(101, True, 700, 3)]
+    assert _collect_dtmf(packets) == ["3", "3"]
+
+
+def test_rfc2833_rx_marker_style_unchanged():
+    # Zoiper-style: marker on the first packet, repeats after it.
+    packets = [_te_packet(101, True, 700, 3)]
+    packets += [_te_packet(101, False, 700, 3) for _ in range(4)]
+    assert _collect_dtmf(packets) == ["3"]
+
+
+def test_rfc2833_rx_unnegotiated_payload_type():
+    # telephone-event absent from the remote SDP: a 4-byte dynamic-PT payload
+    # is still accepted rather than dropped.
+    packets = [_te_packet(96, False, 500, 9) for _ in range(3)]
+    assert _collect_dtmf(packets, dtmf_pt=-1) == ["9"]
+
+
+def test_rfc2833_rx_does_not_swallow_audio():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.dtmf_pt = 101
+        audio = []
+        session.on_audio = audio.append
+        pcmu = bytes([0x80, 0]) + struct.pack("!HII", 1, 100, 0x1234) + b"\xff" * 160
+        session._receive_impl(pcmu)
+        return audio
+
+    audio = asyncio.run(run())
+    # 160 bytes of G.711 decode to 160 16-bit samples.
+    assert len(audio) == 1 and len(audio[0]) == 320
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Handle SIP INFO DTMF (application/dtmf-relay, application/dtmf, audio/telephone-event), parsing Signal=/d=/bare-digit bodies and RFC 4733 numeric event codes. INFO was previously answered 200 OK and the digit discarded.
- Key RFC 2833 events off the RTP timestamp instead of requiring the marker bit, so devices that never set it are still recognised; a marker still forces a new event so a repeated digit is not swallowed.
- Accept a 4-byte payload on a dynamic PT when the remote never negotiated telephone-event, instead of dropping the packet.
- Warn on call setup when telephone-event was not negotiated, so the cause is visible in the log.
- Document inbound DTMF support (and that in-band tones are not detected) in the README.

Adds 9 regression tests covering the INFO parser and each RTP receive path, including that Zoiper-style marker packets and normal audio are unaffected.

Bump version to 1.2.1