### PR TITLE
feat: add G.722 wideband codec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A native custom integration for Home Assistant to connect directly to a SIP serv
 - **Native Media Player Entity**: Exposes the SIP line as a `media_player` entity. Stream standard TTS messages (e.g. Google Translate, Piper, Nabu Casa) or audio URLs directly into the active SIP call.
 - **Custom Telephony Services**: Complete set of services to control SIP calls (`sip.dial`, `sip.hangup`, `sip.answer`, `sip.send_dtmf`, `sip.start_recording`, `sip.stop_recording`, `sip.start_assist`).
 - **Interactive Voice Response (IVR) Engine**: Construct nested DTMF automated phone trees with TTS prompt templates, custom PIN authentication, and native Home Assistant service triggers.
-- **Voice Assist Integration**: Bidirectional audio streaming between the SIP call and Home Assistant's Voice Assist pipeline, utilizing active 8kHz to 16kHz resampling.
+- **Wideband Audio (G.722)**: Negotiates G.722 (16 kHz) when the remote party supports it, falling back to G.711 µ-law / A-law. Voice Assist receives true 16 kHz PCM on G.722 calls instead of upsampled narrowband.
 - **Sensors**: Exposes real-time registration status, call state (line active), and last caller ID.
 
 ## Installation

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -391,6 +391,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass,
             play_source_fn=client.play_source,
             on_done_fn=on_assist_done,
+            sample_rate=client.codec.sample_rate,
         )
         client.set_sink(assist_bridge)
         assist_bridge.start()
@@ -669,7 +670,9 @@ async def async_register_services(hass: HomeAssistant) -> None:
                 if data["config"].username not in target_file:
                     target_file = f"{base}_{data['config'].username}{ext}"
 
-            recorder = WavRecorderSink(target_file)
+            recorder = WavRecorderSink(
+                target_file, sample_rate=client.codec.sample_rate
+            )
             client.set_sink(recorder)
             data["recorder"] = recorder
             rec_data = {"sip_account": data["config"].username, "recording_file": target_file}

--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -35,17 +35,25 @@ class AssistAudioStream(AsyncIterable[bytes]):
         """Initialize the audio stream."""
         self.queue: asyncio.Queue[bytes] = asyncio.Queue()
 
-    def feed_audio_8khz(self, pcm_8khz: bytes) -> None:
-        """Receive 8kHz s16le mono PCM, resample to 16kHz, and queue.
+    def feed_audio(self, pcm_le: bytes, sample_rate: int) -> None:
+        """Queue PCM for Assist, upsampling 8 kHz → 16 kHz when needed.
 
-        Uses simple sample duplication (duplicating each 2-byte sample).
+        When the SIP codec is already 16 kHz (G.722), PCM is passed through.
+        For 8 kHz (G.711), each 2-byte sample is duplicated.
         """
-        resampled = bytearray(len(pcm_8khz) * 2)
-        for i in range(0, len(pcm_8khz), 2):
-            sample = pcm_8khz[i : i + 2]
+        if sample_rate == 16000:
+            self.queue.put_nowait(pcm_le)
+            return
+        resampled = bytearray(len(pcm_le) * 2)
+        for i in range(0, len(pcm_le), 2):
+            sample = pcm_le[i : i + 2]
             resampled[i * 2 : i * 2 + 2] = sample
             resampled[i * 2 + 2 : i * 2 + 4] = sample
         self.queue.put_nowait(bytes(resampled))
+
+    def feed_audio_8khz(self, pcm_8khz: bytes) -> None:
+        """Backward-compatible wrapper around :meth:`feed_audio`."""
+        self.feed_audio(pcm_8khz, 8000)
 
     def __aiter__(self) -> AssistAudioStream:
         """Return the iterator."""
@@ -65,12 +73,14 @@ class AssistBridge(AudioSink):
         play_source_fn: Callable[[AudioSource], None],
         on_done_fn: Callable[[], None],
         pipeline_id: str | None = None,
+        sample_rate: int = 8000,
     ) -> None:
         """Initialize the Assist bridge."""
         self.hass = hass
         self.play_source = play_source_fn
         self.on_done = on_done_fn
         self.pipeline_id = pipeline_id
+        self.sample_rate = sample_rate
 
         self.audio_stream = AssistAudioStream()
         self.pipeline_task: asyncio.Task | None = None
@@ -82,9 +92,9 @@ class AssistBridge(AudioSink):
         self.pipeline_task = asyncio.create_task(self._run_pipeline())
 
     def write(self, pcm_le: bytes) -> None:
-        """Receive incoming 8kHz PCM from SIP client and feed it to Assist."""
+        """Receive incoming PCM from SIP client and feed it to Assist."""
         if self.is_active:
-            self.audio_stream.feed_audio_8khz(pcm_le)
+            self.audio_stream.feed_audio(pcm_le, self.sample_rate)
 
     def close(self) -> None:
         """Stop the bridge and cancel running tasks."""

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -17,5 +17,5 @@
     "assist_pipeline",
     "stt"
   ],
-  "version": "1.4.0"
+  "version": "1.5.0"
 }

--- a/custom_components/sip/sip_client/audio.py
+++ b/custom_components/sip/sip_client/audio.py
@@ -17,8 +17,6 @@ import wave
 from abc import ABC, abstractmethod
 from typing import Callable
 
-from .rtp_session import FRAME_BYTES
-
 _LOGGER = logging.getLogger(__name__)
 
 PushFn = Callable[[bytes], None]
@@ -26,7 +24,7 @@ ActiveFn = Callable[[], bool]
 
 
 class AudioSource(ABC):
-    """Produces 8 kHz / s16le / mono PCM and pushes it into the RTP TX path."""
+    """Produces s16le / mono PCM at the negotiated sample rate for RTP TX."""
 
     @abstractmethod
     async def run(self, push: PushFn, is_active: ActiveFn) -> None:
@@ -34,7 +32,7 @@ class AudioSource(ABC):
 
 
 class AudioSink(ABC):
-    """Consumes 8 kHz / s16le / mono PCM coming off the RTP RX path."""
+    """Consumes s16le / mono PCM coming off the RTP RX path."""
 
     @abstractmethod
     def write(self, pcm_le: bytes) -> None:
@@ -60,11 +58,11 @@ class NullSink(AudioSink):
 class WavRecorderSink(AudioSink):
     """Records received audio to a WAV file (handy for verifying the RX path)."""
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, sample_rate: int = 8000) -> None:
         self._wav = wave.open(path, "wb")
         self._wav.setnchannels(1)
         self._wav.setsampwidth(2)
-        self._wav.setframerate(8000)
+        self._wav.setframerate(sample_rate)
 
     def write(self, pcm_le: bytes) -> None:
         self._wav.writeframes(pcm_le)
@@ -77,12 +75,15 @@ class WavRecorderSink(AudioSink):
 
 
 class FfmpegAudioSource(AudioSource):
-    """Decode any media (file path, URL, or raw bytes) to 8 kHz mono via ffmpeg.
+    """Decode any media (file path, URL, or raw bytes) to mono PCM via ffmpeg.
 
     ffmpeg transparently handles WAV/MP3/etc. and produces the exact format the
-    G.711 encoder expects, so this single source covers audio files, HTTP URLs
-    and TTS output. It paces itself at ~real time so the RTP TX buffer stays
+    active codec encoder expects, so this single source covers audio files, HTTP
+    URLs and TTS output. It paces itself at ~real time so the RTP TX buffer stays
     small (no dropped audio).
+
+    ``sample_rate`` / ``pcm_frame_bytes`` default to G.711 (8 kHz / 320 B). Call
+    :meth:`configure` after negotiation when a different rate is active.
     """
 
     def __init__(
@@ -91,12 +92,23 @@ class FfmpegAudioSource(AudioSource):
         *,
         url: str | None = None,
         data: bytes | None = None,
+        sample_rate: int = 8000,
+        pcm_frame_bytes: int | None = None,
     ) -> None:
         if (url is None) == (data is None):
             raise ValueError("Provide exactly one of url/data")
         self._bin = ffmpeg_bin
         self._url = url
         self._data = data
+        self._sample_rate = sample_rate
+        self._pcm_frame_bytes = (
+            pcm_frame_bytes if pcm_frame_bytes is not None else sample_rate // 50 * 2
+        )
+
+    def configure(self, sample_rate: int, pcm_frame_bytes: int) -> None:
+        """Update output rate to match the negotiated codec."""
+        self._sample_rate = sample_rate
+        self._pcm_frame_bytes = pcm_frame_bytes
 
     async def run(self, push: PushFn, is_active: ActiveFn) -> None:
         src = self._url if self._url is not None else "pipe:0"
@@ -110,7 +122,7 @@ class FfmpegAudioSource(AudioSource):
             "-ac",
             "1",
             "-ar",
-            "8000",
+            str(self._sample_rate),
             "-f",
             "s16le",
             "pipe:1",
@@ -127,7 +139,7 @@ class FfmpegAudioSource(AudioSource):
             # Read ~20 ms at a time and pace to real time so the RTP buffer
             # never overflows and drops audio.
             while is_active():
-                chunk = await proc.stdout.read(FRAME_BYTES)
+                chunk = await proc.stdout.read(self._pcm_frame_bytes)
                 if not chunk:
                     break
                 push(chunk)

--- a/custom_components/sip/sip_client/codecs.py
+++ b/custom_components/sip/sip_client/codecs.py
@@ -1,0 +1,153 @@
+"""Audio codec registry.
+
+One Codec entry per negotiable payload type. SDP generation, codec selection and
+the RTP receive gate are all derived from SUPPORTED, so adding a codec is a
+one-line change here.
+
+Stateful codecs (G.722) need per-call encoder/decoder instances. Codec exposes
+``new_encoder`` / ``new_decoder`` factories; G.711 returns stateless adapters.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from . import g711
+from . import g722
+
+if TYPE_CHECKING:
+    from .sip_message import SdpInfo
+
+FRAME_SEC = 0.02
+
+# PCM <-> payload transformers produced per call (or reused when stateless).
+EncodeFn = Callable[[bytes], bytes]
+DecodeFn = Callable[[bytes], bytes]
+
+
+def _g711_encoder(payload_type: int) -> EncodeFn:
+    def encode(pcm: bytes) -> bytes:
+        return g711.encode(pcm, payload_type)
+
+    return encode
+
+
+def _g711_decoder(payload_type: int) -> DecodeFn:
+    def decode(data: bytes) -> bytes:
+        return g711.decode(data, payload_type)
+
+    return decode
+
+
+@dataclass(frozen=True)
+class Codec:
+    name: str  # SDP rtpmap name, e.g. "PCMU", "G722"
+    payload_type: int  # static PT, or negotiated dynamic PT after choose()
+    clock_rate: int  # RTP timestamp clock (G.722: 8000!)
+    sample_rate: int  # real PCM rate (G.722: 16000)
+    new_encoder: Callable[[], EncodeFn]
+    new_decoder: Callable[[], DecodeFn]
+
+    @property
+    def pcm_frame_bytes(self) -> int:
+        """Bytes of s16le PCM in one 20 ms frame."""
+        return int(self.sample_rate * FRAME_SEC) * 2
+
+    @property
+    def ts_increment(self) -> int:
+        """RTP timestamp ticks per 20 ms frame."""
+        return int(self.clock_rate * FRAME_SEC)
+
+    def with_payload_type(self, pt: int) -> Codec:
+        """Return a copy bound to a (possibly dynamic) payload type."""
+        if pt == self.payload_type:
+            return self
+        return Codec(
+            self.name,
+            pt,
+            self.clock_rate,
+            self.sample_rate,
+            self.new_encoder,
+            self.new_decoder,
+        )
+
+
+def _g722_encoder() -> EncodeFn:
+    return g722.G722Encoder().encode
+
+
+def _g722_decoder() -> DecodeFn:
+    return g722.G722Decoder().decode
+
+
+PCMU = Codec(
+    "PCMU",
+    0,
+    8000,
+    8000,
+    lambda: _g711_encoder(0),
+    lambda: _g711_decoder(0),
+)
+PCMA = Codec(
+    "PCMA",
+    8,
+    8000,
+    8000,
+    lambda: _g711_encoder(8),
+    lambda: _g711_decoder(8),
+)
+G722 = Codec(
+    "G722",
+    9,
+    8000,  # RTP clock (RFC 3551); real PCM is 16 kHz
+    16000,
+    _g722_encoder,
+    _g722_decoder,
+)
+
+# Order defines both the SDP offer order and the selection preference.
+SUPPORTED: tuple[Codec, ...] = (G722, PCMU, PCMA)
+BY_PT: dict[int, Codec] = {c.payload_type: c for c in SUPPORTED}
+DEFAULT: Codec = PCMU
+
+TELEPHONE_EVENT_PT = 101
+
+
+def choose(sdp: SdpInfo) -> Codec:
+    """Pick the most preferred codec the remote also offered.
+
+    Prefers a static payload type present in ``offered_pts``. If the remote only
+    advertised a codec under a dynamic PT (``a=rtpmap:96 PCMU/8000``), fall back
+    to the name-based ``pcmu_pt`` / ``pcma_pt`` / ``g722_pt`` fields.
+    """
+    named = {
+        "G722": sdp.g722_pt,
+        "PCMU": sdp.pcmu_pt,
+        "PCMA": sdp.pcma_pt,
+    }
+    for codec in SUPPORTED:
+        if codec.payload_type in sdp.offered_pts:
+            return codec
+    for codec in SUPPORTED:
+        npt = named.get(codec.name, -1)
+        if npt >= 0:
+            return codec.with_payload_type(npt)
+    return DEFAULT
+
+
+def sdp_media_line(port: int, only: Codec | None = None) -> str:
+    """Build the ``m=audio`` line. Pass ``only`` to answer with one codec (RFC 3264)."""
+    if only is not None:
+        pts = str(only.payload_type)
+    else:
+        pts = " ".join(str(c.payload_type) for c in SUPPORTED)
+    return f"m=audio {port} RTP/AVP {pts} {TELEPHONE_EVENT_PT}\r\n"
+
+
+def sdp_rtpmaps(only: Codec | None = None) -> str:
+    """Build ``a=rtpmap`` lines. Pass ``only`` for a single-codec answer."""
+    entries = (only,) if only is not None else SUPPORTED
+    lines = "".join(
+        f"a=rtpmap:{c.payload_type} {c.name}/{c.clock_rate}\r\n" for c in entries
+    )
+    return lines + f"a=rtpmap:{TELEPHONE_EVENT_PT} telephone-event/8000\r\n"

--- a/custom_components/sip/sip_client/g722.py
+++ b/custom_components/sip/sip_client/g722.py
@@ -1,0 +1,407 @@
+"""ITU-T G.722 wideband ADPCM (64 kbit/s) — pure-Python port.
+
+PCM is signed 16-bit little-endian, 16 kHz, mono. Encoded frames are 4:1
+(320 samples / 20 ms -> 160 bytes).
+
+Ported from sippy/libg722 (``g722_encode.c`` / ``g722_decode.c``), which Steve
+Underwood placed in the public domain. Based on the Carnegie Mellon ADPCM
+program (Copyright (c) CMU 1993, Chengxiang Lu and Alex Hauptmann); use for any
+research or commercial purpose is unrestricted — acknowledgement of origin
+appreciated.
+
+Only the 64 kbit/s mode used in SIP practice is implemented. Encoder and
+decoder are stateful across frames; create one instance per media stream.
+"""
+from __future__ import annotations
+
+import array
+import struct
+
+
+def _saturate(amp: int) -> int:
+    if amp > 32767:
+        return 32767
+    if amp < -32768:
+        return -32768
+    return amp
+
+
+class _Band:
+    __slots__ = (
+        "s", "sp", "sz", "r", "a", "ap", "p", "d", "b", "bp", "sg", "nb", "det",
+    )
+
+    def __init__(self, det: int) -> None:
+        self.s = 0
+        self.sp = 0
+        self.sz = 0
+        self.r = [0, 0, 0]
+        self.a = [0, 0, 0]
+        self.ap = [0, 0, 0]
+        self.p = [0, 0, 0]
+        self.d = [0, 0, 0, 0, 0, 0, 0]
+        self.b = [0, 0, 0, 0, 0, 0, 0]
+        self.bp = [0, 0, 0, 0, 0, 0, 0]
+        self.sg = [0, 0, 0, 0, 0, 0, 0]
+        self.nb = 0
+        self.det = det
+
+
+def _block4(band: _Band, d: int) -> None:
+    r = band.r
+    a = band.a
+    ap = band.ap
+    p = band.p
+    dd = band.d
+    b = band.b
+    bp = band.bp
+    sg = band.sg
+
+    # Block 4, RECONS
+    dd[0] = d
+    r[0] = _saturate(band.s + d)
+
+    # Block 4, PARREC
+    p[0] = _saturate(band.sz + d)
+
+    # Block 4, UPPOL2
+    sg[0] = p[0] >> 15
+    sg[1] = p[1] >> 15
+    sg[2] = p[2] >> 15
+    wd1 = _saturate(a[1] << 2)
+
+    wd2 = -wd1 if sg[0] == sg[1] else wd1
+    if wd2 > 32767:
+        wd2 = 32767
+    wd3 = (wd2 >> 7) + (128 if sg[0] == sg[2] else -128)
+    wd3 += (a[2] * 32512) >> 15
+    if wd3 > 12288:
+        wd3 = 12288
+    elif wd3 < -12288:
+        wd3 = -12288
+    ap[2] = wd3
+
+    # Block 4, UPPOL1
+    sg[0] = p[0] >> 15
+    sg[1] = p[1] >> 15
+    wd1 = 192 if sg[0] == sg[1] else -192
+    wd2 = (a[1] * 32640) >> 15
+
+    ap[1] = _saturate(wd1 + wd2)
+    wd3 = _saturate(15360 - ap[2])
+    if ap[1] > wd3:
+        ap[1] = wd3
+    elif ap[1] < -wd3:
+        ap[1] = -wd3
+
+    # Block 4, UPZERO
+    wd1 = 0 if d == 0 else 128
+    sg[0] = d >> 15
+    for i in range(1, 7):
+        sg[i] = dd[i] >> 15
+        wd2 = wd1 if sg[i] == sg[0] else -wd1
+        bp[i] = _saturate(wd2 + ((b[i] * 32640) >> 15))
+
+    # Block 4, DELAYA
+    dd[6] = dd[5]
+    dd[5] = dd[4]
+    dd[4] = dd[3]
+    dd[3] = dd[2]
+    dd[2] = dd[1]
+    dd[1] = dd[0]
+    b[6] = bp[6]
+    b[5] = bp[5]
+    b[4] = bp[4]
+    b[3] = bp[3]
+    b[2] = bp[2]
+    b[1] = bp[1]
+
+    r[2] = r[1]
+    r[1] = r[0]
+    p[2] = p[1]
+    p[1] = p[0]
+    a[2] = ap[2]
+    a[1] = ap[1]
+
+    # Block 4, FILTEP
+    wd1 = _saturate(r[1] + r[1])
+    wd1 = (a[1] * wd1) >> 15
+    wd2 = _saturate(r[2] + r[2])
+    wd2 = (a[2] * wd2) >> 15
+    band.sp = _saturate(wd1 + wd2)
+
+    # Block 4, FILTEZ
+    sz = 0
+    for i in range(6, 0, -1):
+        sz += (b[i] * _saturate(dd[i] + dd[i])) >> 15
+    band.sz = _saturate(sz)
+
+    # Block 4, PREDIC
+    band.s = _saturate(band.sp + band.sz)
+
+
+_QMF = (3, -11, 12, 32, -210, 951, 3876, -805, 362, -156, 53, -11)
+
+_Q6 = (
+    0, 35, 72, 110, 150, 190, 233, 276,
+    323, 370, 422, 473, 530, 587, 650, 714,
+    786, 858, 940, 1023, 1121, 1219, 1339, 1458,
+    1612, 1765, 1980, 2195, 2557, 2919, 0, 0,
+)
+_ILN = (
+    0, 63, 62, 31, 30, 29, 28, 27,
+    26, 25, 24, 23, 22, 21, 20, 19,
+    18, 17, 16, 15, 14, 13, 12, 11,
+    10, 9, 8, 7, 6, 5, 4, 0,
+)
+_ILP = (
+    0, 61, 60, 59, 58, 57, 56, 55,
+    54, 53, 52, 51, 50, 49, 48, 47,
+    46, 45, 44, 43, 42, 41, 40, 39,
+    38, 37, 36, 35, 34, 33, 32, 0,
+)
+_WL = (-60, -30, 58, 172, 334, 538, 1198, 3042)
+_RL42 = (0, 7, 6, 5, 4, 3, 2, 1, 7, 6, 5, 4, 3, 2, 1, 0)
+_ILB = (
+    2048, 2093, 2139, 2186, 2233, 2282, 2332,
+    2383, 2435, 2489, 2543, 2599, 2656, 2714,
+    2774, 2834, 2896, 2960, 3025, 3091, 3158,
+    3228, 3298, 3371, 3444, 3520, 3597, 3676,
+    3756, 3838, 3922, 4008,
+)
+_QM4 = (
+    0, -20456, -12896, -8968,
+    -6288, -4240, -2584, -1200,
+    20456, 12896, 8968, 6288,
+    4240, 2584, 1200, 0,
+)
+_QM2 = (-7408, -1616, 7408, 1616)
+_IHN = (0, 1, 0)
+_IHP = (0, 3, 2)
+_WH = (0, -214, 798)
+_RH2 = (2, 1, 2, 1)
+_QM6 = (
+    -136, -136, -136, -136,
+    -24808, -21904, -19008, -16704,
+    -14984, -13512, -12280, -11192,
+    -10232, -9360, -8576, -7856,
+    -7192, -6576, -6000, -5456,
+    -4944, -4464, -4008, -3576,
+    -3168, -2776, -2400, -2032,
+    -1688, -1360, -1040, -728,
+    24808, 21904, 19008, 16704,
+    14984, 13512, 12280, 11192,
+    10232, 9360, 8576, 7856,
+    7192, 6576, 6000, 5456,
+    4944, 4464, 4008, 3576,
+    3168, 2776, 2400, 2032,
+    1688, 1360, 1040, 728,
+    432, 136, -432, -136,
+)
+
+
+class G722Encoder:
+    """Stateful G.722 encoder (64 kbit/s, 16 kHz PCM in)."""
+
+    __slots__ = ("_x", "_xi", "_band0", "_band1")
+
+    def __init__(self) -> None:
+        # 24-sample QMF history in a 48-slot buffer; _xi points at the next
+        # write position (starts at 22 so the first pair lands at x[22]/x[23],
+        # matching the C reference after its initial shuffle of zeros).
+        self._x = [0] * 48
+        self._xi = 22
+        self._band0 = _Band(32)
+        self._band1 = _Band(8)
+
+    def encode(self, pcm_le: bytes) -> bytes:
+        """Encode s16le PCM to G.722. Length must be a multiple of 4 bytes."""
+        n = len(pcm_le) // 2
+        if n & 1:
+            raise ValueError("G.722 encode needs an even number of samples")
+        amp = struct.unpack_from("<%dh" % n, pcm_le)
+        out = bytearray(n >> 1)
+        band0 = self._band0
+        band1 = self._band1
+        x = self._x
+        xi = self._xi
+        qmf = _QMF
+        o = 0
+        j = 0
+        while j < n:
+            # Place the new pair at the end of the 24-sample window.
+            pos = xi
+            x[pos] = amp[j]
+            x[pos + 1] = amp[j + 1]
+            j += 2
+
+            # Window starts 22 samples before the new pair.
+            base = pos - 22
+            sumeven = 0
+            sumodd = 0
+            for i in range(12):
+                sumodd += x[base + 2 * i] * qmf[i]
+                sumeven += x[base + 2 * i + 1] * qmf[11 - i]
+            xlow = (sumeven + sumodd) >> 14
+            xhigh = (sumeven - sumodd) >> 14
+
+            xi = pos + 2
+            if xi >= 24:
+                # Slide the live 24-sample window back to the start of the buffer.
+                x[0:24] = x[xi - 24 : xi]
+                xi = 24
+
+            # Block 1L, SUBTRA / QUANTL
+            el = _saturate(xlow - band0.s)
+            wd = el if el >= 0 else -(el + 1)
+            i = 1
+            det0 = band0.det
+            while i < 30:
+                if wd < (_Q6[i] * det0) >> 12:
+                    break
+                i += 1
+            ilow = _ILN[i] if el < 0 else _ILP[i]
+
+            # Block 2L, INVQAL
+            ril = ilow >> 2
+            dlow = (det0 * _QM4[ril]) >> 15
+
+            # Block 3L, LOGSCL / SCALEL
+            nb = ((band0.nb * 127) >> 7) + _WL[_RL42[ril]]
+            if nb < 0:
+                nb = 0
+            elif nb > 18432:
+                nb = 18432
+            band0.nb = nb
+            wd1 = (nb >> 6) & 31
+            wd2 = 8 - (nb >> 11)
+            wd3 = (_ILB[wd1] << -wd2) if wd2 < 0 else (_ILB[wd1] >> wd2)
+            band0.det = wd3 << 2
+
+            _block4(band0, dlow)
+
+            # Block 1H, SUBTRA / QUANTH
+            eh = _saturate(xhigh - band1.s)
+            wd = eh if eh >= 0 else -(eh + 1)
+            det1 = band1.det
+            mih = 2 if wd >= ((564 * det1) >> 12) else 1
+            ihigh = _IHN[mih] if eh < 0 else _IHP[mih]
+
+            # Block 2H, INVQAH
+            dhigh = (det1 * _QM2[ihigh]) >> 15
+
+            # Block 3H, LOGSCH / SCALEH
+            nb = ((band1.nb * 127) >> 7) + _WH[_RH2[ihigh]]
+            if nb < 0:
+                nb = 0
+            elif nb > 22528:
+                nb = 22528
+            band1.nb = nb
+            wd1 = (nb >> 6) & 31
+            wd2 = 10 - (nb >> 11)
+            wd3 = (_ILB[wd1] << -wd2) if wd2 < 0 else (_ILB[wd1] >> wd2)
+            band1.det = wd3 << 2
+
+            _block4(band1, dhigh)
+            out[o] = ((ihigh << 6) | ilow) & 0xFF
+            o += 1
+
+        self._xi = xi
+        return bytes(out)
+
+
+class G722Decoder:
+    """Stateful G.722 decoder (64 kbit/s, 16 kHz PCM out)."""
+
+    __slots__ = ("_x", "_xi", "_band0", "_band1")
+
+    def __init__(self) -> None:
+        self._x = [0] * 48
+        self._xi = 22
+        self._band0 = _Band(32)
+        self._band1 = _Band(8)
+
+    def decode(self, data: bytes) -> bytes:
+        """Decode G.722 to s16le PCM (2 samples per encoded byte)."""
+        out = array.array("h", [0]) * (len(data) << 1)
+        band0 = self._band0
+        band1 = self._band1
+        x = self._x
+        xi = self._xi
+        qmf = _QMF
+        o = 0
+        for code in data:
+            wd1 = code & 0x3F
+            ihigh = (code >> 6) & 0x03
+            wd2 = _QM6[wd1]
+            wd1 >>= 2
+
+            # Block 5L, LOW BAND INVQBL / RECONS / LIMIT
+            det0 = band0.det
+            wd2 = (det0 * wd2) >> 15
+            rlow = band0.s + wd2
+            if rlow > 16383:
+                rlow = 16383
+            elif rlow < -16384:
+                rlow = -16384
+
+            # Block 2L, INVQAL
+            dlowt = (det0 * _QM4[wd1]) >> 15
+
+            # Block 3L, LOGSCL / SCALEL
+            nb = ((band0.nb * 127) >> 7) + _WL[_RL42[wd1]]
+            if nb < 0:
+                nb = 0
+            elif nb > 18432:
+                nb = 18432
+            band0.nb = nb
+            wd1s = (nb >> 6) & 31
+            wd2s = 8 - (nb >> 11)
+            wd3 = (_ILB[wd1s] << -wd2s) if wd2s < 0 else (_ILB[wd1s] >> wd2s)
+            band0.det = wd3 << 2
+
+            _block4(band0, dlowt)
+
+            # High band
+            det1 = band1.det
+            dhigh = (det1 * _QM2[ihigh]) >> 15
+            rhigh = dhigh + band1.s
+            if rhigh > 16383:
+                rhigh = 16383
+            elif rhigh < -16384:
+                rhigh = -16384
+
+            nb = ((band1.nb * 127) >> 7) + _WH[_RH2[ihigh]]
+            if nb < 0:
+                nb = 0
+            elif nb > 22528:
+                nb = 22528
+            band1.nb = nb
+            wd1s = (nb >> 6) & 31
+            wd2s = 10 - (nb >> 11)
+            wd3 = (_ILB[wd1s] << -wd2s) if wd2s < 0 else (_ILB[wd1s] >> wd2s)
+            band1.det = wd3 << 2
+
+            _block4(band1, dhigh)
+
+            # Receive QMF via ring buffer
+            pos = xi
+            x[pos] = rlow + rhigh
+            x[pos + 1] = rlow - rhigh
+            base = pos - 22
+            xout1 = 0
+            xout2 = 0
+            for i in range(12):
+                xout2 += x[base + 2 * i] * qmf[i]
+                xout1 += x[base + 2 * i + 1] * qmf[11 - i]
+            out[o] = _saturate(xout1 >> 11)
+            out[o + 1] = _saturate(xout2 >> 11)
+            o += 2
+
+            xi = pos + 2
+            if xi >= 24:
+                x[0:24] = x[xi - 24 : xi]
+                xi = 24
+
+        self._xi = xi
+        return out.tobytes()

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -1,8 +1,9 @@
-"""Asyncio RTP audio session for a single G.711 call.
+"""Asyncio RTP audio session for a single negotiated codec.
 
-Owns one UDP socket, paces transmission at 20 ms (160 samples @ 8 kHz), decodes
-received audio and emits / receives RFC 2833 telephone-event (DTMF). All PCM
-exchanged with callers is signed-16-bit-LE, 8 kHz, mono.
+Owns one UDP socket, paces transmission at 20 ms, encodes/decodes via the
+active :class:`codecs.Codec`, and emits / receives RFC 2833 telephone-event
+(DTMF). All PCM exchanged with callers is signed-16-bit-LE mono at the codec's
+sample rate.
 
 Port of rtp_session.cpp. The audio I/O is fully decoupled:
 
@@ -20,16 +21,17 @@ import os
 import struct
 from typing import Callable
 
-from . import g711
+from . import codecs
+from .codecs import Codec
 
 _LOGGER = logging.getLogger(__name__)
 
-SAMPLES_PER_FRAME = 160  # 20 ms @ 8 kHz
-FRAME_BYTES = SAMPLES_PER_FRAME * 2  # s16le
+# G.711 defaults kept as module names for callers that still import them.
+SAMPLES_PER_FRAME = 160  # 20 ms @ 8 kHz clock
+FRAME_BYTES = SAMPLES_PER_FRAME * 2  # s16le @ 8 kHz
 FRAME_SEC = 0.02
-_DTMF_TONE_SAMPLES = 8 * SAMPLES_PER_FRAME  # ~160 ms
+_DTMF_TONE_SAMPLES = 8 * SAMPLES_PER_FRAME  # ~160 ms, in CLOCK ticks
 _DTMF_END_PACKETS = 3
-_TX_BUFFER_MAX = 8000 * 2  # ~1 s of audio (bytes), drop oldest beyond this
 
 
 def _dtmf_char_to_event(c: str) -> int:
@@ -63,7 +65,6 @@ class RtpSession:
         self._sender_task: asyncio.Task | None = None
 
         self._remote: tuple[str, int] | None = None
-        self.payload_type = 0
         self.dtmf_pt = 101
         self.send_silence = True
 
@@ -89,9 +90,44 @@ class RtpSession:
         self.on_audio: Callable[[bytes], None] | None = None
         self.on_dtmf: Callable[[str], None] | None = None
 
+        # Codec-derived pacing / encode state (defaults = G.711 PCMU).
+        self._codec: Codec = codecs.DEFAULT
+        self.payload_type = self._codec.payload_type
+        self._pcm_frame_bytes = self._codec.pcm_frame_bytes
+        self._ts_increment = self._codec.ts_increment
+        self._tx_buffer_max = self._codec.sample_rate * 2
+        self._encode = self._codec.new_encoder()
+        self._decode = self._codec.new_decoder()
+        # Per-PT decoder cache so off-PT (or late) packets keep ADPCM state.
+        self._decoders: dict[int, Callable[[bytes], bytes]] = {
+            self.payload_type: self._decode
+        }
+
     # -- configuration --------------------------------------------------
     def set_remote(self, ip: str, port: int) -> None:
         self._remote = (ip, port)
+
+    def set_codec(self, codec: Codec) -> None:
+        """Bind the negotiated codec and (re)create encoder/decoder state."""
+        self._codec = codec
+        self.payload_type = codec.payload_type
+        self._pcm_frame_bytes = codec.pcm_frame_bytes
+        self._ts_increment = codec.ts_increment
+        self._tx_buffer_max = codec.sample_rate * 2
+        self._encode = codec.new_encoder()
+        self._decode = codec.new_decoder()
+        self._decoders = {codec.payload_type: self._decode}
+
+    def _decoder_for(self, pt: int) -> Callable[[bytes], bytes] | None:
+        cached = self._decoders.get(pt)
+        if cached is not None:
+            return cached
+        codec = codecs.BY_PT.get(pt)
+        if codec is None:
+            return None
+        decode = codec.new_decoder()
+        self._decoders[pt] = decode
+        return decode
 
     @property
     def running(self) -> bool:
@@ -118,6 +154,8 @@ class RtpSession:
         self._dtmf_queue.clear()
         self._dtmf_active = False
         self._rx_dtmf_timestamp = -1
+        # Fresh codec state for this call (important for stateful codecs).
+        self.set_codec(self._codec)
         self._sender_task = self._loop.create_task(self._sender())
         _LOGGER.info(
             "RTP started on port %s (pt=%s, dtmf_pt=%s)",
@@ -150,12 +188,12 @@ class RtpSession:
 
     # -- TX -------------------------------------------------------------
     def push_tx_audio(self, pcm_le: bytes) -> None:
-        """Queue captured PCM (s16le, 8 kHz, mono) for transmission."""
+        """Queue captured PCM (s16le, mono, codec sample rate) for transmission."""
         if self._transport is None:
             return
         self._tx_buffer.extend(pcm_le)
-        if len(self._tx_buffer) > _TX_BUFFER_MAX:
-            overflow = len(self._tx_buffer) - _TX_BUFFER_MAX
+        if len(self._tx_buffer) > self._tx_buffer_max:
+            overflow = len(self._tx_buffer) - self._tx_buffer_max
             del self._tx_buffer[:overflow]
 
     def queue_dtmf(self, digits: str) -> None:
@@ -165,7 +203,11 @@ class RtpSession:
         self._dtmf_queue.extend(digits)
 
     def tx_idle(self) -> bool:
-        return len(self._tx_buffer) < FRAME_BYTES and not self._dtmf_queue and not self._dtmf_active
+        return (
+            len(self._tx_buffer) < self._pcm_frame_bytes
+            and not self._dtmf_queue
+            and not self._dtmf_active
+        )
 
     # -- packet building ------------------------------------------------
     def _rtp_header(self, marker: bool, pt: int, timestamp: int) -> bytes:
@@ -184,9 +226,9 @@ class RtpSession:
 
     def _send_audio_packet(self, frame: bytes) -> None:
         header = self._rtp_header(self._first_packet, self.payload_type, self._timestamp)
-        self._send(header + g711.encode(frame, self.payload_type))
+        self._send(header + self._encode(frame))
         self._seq += 1
-        self._timestamp += SAMPLES_PER_FRAME
+        self._timestamp += self._ts_increment
         self._first_packet = False
 
     def _send_dtmf_packet(self) -> None:
@@ -217,13 +259,14 @@ class RtpSession:
             self._dtmf_end_packets += 1
             if self._dtmf_end_packets >= _DTMF_END_PACKETS:
                 self._dtmf_active = False
+                # DTMF durations are in 8 kHz clock ticks for both codecs.
                 self._timestamp = self._dtmf_timestamp + self._dtmf_duration + SAMPLES_PER_FRAME
                 self._first_packet = True  # re-mark audio after DTMF
         else:
             self._dtmf_duration += SAMPLES_PER_FRAME
 
     def _silence_frame(self) -> bytes:
-        return b"\x00" * FRAME_BYTES
+        return b"\x00" * self._pcm_frame_bytes
 
     # -- sender loop ----------------------------------------------------
     async def _sender(self) -> None:
@@ -234,9 +277,9 @@ class RtpSession:
                 if self._remote is not None:
                     if self._dtmf_active or self._dtmf_queue:
                         self._send_dtmf_packet()
-                    elif len(self._tx_buffer) >= FRAME_BYTES:
-                        frame = bytes(self._tx_buffer[:FRAME_BYTES])
-                        del self._tx_buffer[:FRAME_BYTES]
+                    elif len(self._tx_buffer) >= self._pcm_frame_bytes:
+                        frame = bytes(self._tx_buffer[: self._pcm_frame_bytes])
+                        del self._tx_buffer[: self._pcm_frame_bytes]
                         self._send_audio_packet(frame)
                     elif self.send_silence:
                         self._send_audio_packet(self._silence_frame())
@@ -246,7 +289,8 @@ class RtpSession:
             if delay > 0:
                 await asyncio.sleep(delay)
             else:
-                next_t = self._loop.time()  # we fell behind; resync pacing
+                # Running behind; resync so we don't spin.
+                next_t = self._loop.time()
 
     # -- RX -------------------------------------------------------------
     def _receive(self, data: bytes) -> None:
@@ -301,7 +345,11 @@ class RtpSession:
                     self.on_dtmf(c)
             return
 
-        if pt not in (0, 8):
+        # DTMF (including the unnegotiated dynamic-PT fallback above) already
+        # returned. Only decode payload types we know as audio codecs, and keep
+        # a per-PT decoder so stateful codecs (G.722) are not reset every packet.
+        decode = self._decoder_for(pt)
+        if decode is None:
             return
         if self.on_audio is not None:
-            self.on_audio(g711.decode(data[header_len:], pt))
+            self.on_audio(decode(data[header_len:]))

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -14,6 +14,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable
 
+from . import codecs
 from . import sip_message as sm
 from .audio import AudioSink, AudioSource, NullSink
 from .rtp_session import RtpSession
@@ -58,14 +59,6 @@ class SipCallbacks:
     on_call_ended: Callable[[], None] | None = None
     on_dtmf: Callable[[str], None] | None = None
     on_playback_done: Callable[[], None] | None = None
-
-
-def _choose_payload(sdp: sm.SdpInfo) -> int:
-    if sdp.pcmu_pt >= 0:
-        return sdp.pcmu_pt
-    if sdp.pcma_pt >= 0:
-        return sdp.pcma_pt
-    return 0
 
 
 _INFO_DTMF_TYPES = ("application/dtmf-relay", "application/dtmf", "audio/telephone-event")
@@ -177,7 +170,8 @@ class SipClient:
         # negotiated media
         self._remote_rtp_ip = ""
         self._remote_rtp_port = 0
-        self._chosen_pt = 0
+        self._codec: codecs.Codec = codecs.DEFAULT
+        self._chosen_pt = self._codec.payload_type
         self._remote_dtmf_pt = -1
         self._media_active = False
 
@@ -194,6 +188,11 @@ class SipClient:
         self.auto_answer_checker: Callable[[str], bool] | None = None
 
     # ------------------------------------------------------------------
+    @property
+    def codec(self) -> codecs.Codec:
+        """Negotiated audio codec for the current / last dialog."""
+        return self._codec
+
     @property
     def in_call(self) -> bool:
         return self.state == SipState.IN_CALL
@@ -555,7 +554,13 @@ class SipClient:
         except Exception:  # noqa: BLE001
             _LOGGER.exception("Ring timeout handler error")
 
-    def _local_sdp(self) -> str:
+    def _local_sdp(self, only: codecs.Codec | None = None) -> str:
+        """Build a local SDP body.
+
+        With ``only=None`` this is a full offer (all supported codecs). Pass the
+        negotiated codec for an answer so we do not re-advertise codecs the
+        remote never offered (RFC 3264).
+        """
         sid = str(int(time.time()))
         return (
             "v=0\r\n"
@@ -563,10 +568,8 @@ class SipClient:
             "s=homeassistant\r\n"
             f"c=IN IP4 {self._local_ip}\r\n"
             "t=0 0\r\n"
-            f"m=audio {self.config.local_rtp_port} RTP/AVP 0 8 101\r\n"
-            "a=rtpmap:0 PCMU/8000\r\n"
-            "a=rtpmap:8 PCMA/8000\r\n"
-            "a=rtpmap:101 telephone-event/8000\r\n"
+            f"{codecs.sdp_media_line(self.config.local_rtp_port, only=only)}"
+            f"{codecs.sdp_rtpmaps(only=only)}"
             "a=fmtp:101 0-15\r\n"
             "a=ptime:20\r\n"
             "a=sendrecv\r\n"
@@ -731,11 +734,12 @@ class SipClient:
         if sdp.connection_ip:
             self._remote_rtp_ip = sdp.connection_ip
         self._remote_rtp_port = sdp.audio_port
-        self._chosen_pt = _choose_payload(sdp)
+        self._codec = codecs.choose(sdp)
+        self._chosen_pt = self._codec.payload_type
         self._remote_dtmf_pt = sdp.telephone_event_pt
 
         # Update RTP session with negotiated values
-        self.rtp.payload_type = self._chosen_pt
+        self.rtp.set_codec(self._codec)
         if self._remote_dtmf_pt >= 0:
             self.rtp.dtmf_pt = self._remote_dtmf_pt
 
@@ -761,7 +765,8 @@ class SipClient:
         to = req.header("To")
         if "tag=" not in to:
             to += f";tag={self._d_local_tag}"
-        sdp = self._local_sdp() if with_sdp else ""
+        # Answers carry only the negotiated codec (RFC 3264); offers use the full set.
+        sdp = self._local_sdp(only=self._codec) if with_sdp else ""
         msg = (
             f"SIP/2.0 {code} {reason}\r\n"
             f"Via: {req.header('Via')}\r\n"
@@ -976,7 +981,7 @@ class SipClient:
         if not self._remote_rtp_ip or not self._remote_rtp_port:
             _LOGGER.warning("No remote RTP endpoint; media not started")
             return
-        self.rtp.payload_type = self._chosen_pt
+        self.rtp.set_codec(self._codec)
         self.rtp.dtmf_pt = self._remote_dtmf_pt
         self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
         self.rtp.on_audio = self._on_rx_audio
@@ -1025,6 +1030,9 @@ class SipClient:
 
     async def _run_source(self, source: AudioSource) -> None:
         try:
+            configure = getattr(source, "configure", None)
+            if callable(configure):
+                configure(self._codec.sample_rate, self._codec.pcm_frame_bytes)
             await source.run(self.rtp.push_tx_audio, lambda: self.in_call)
             # Wait for queued audio to actually leave the RTP buffer before
             # signalling completion, so a caller that hangs up on playback-done

--- a/custom_components/sip/sip_client/sip_message.py
+++ b/custom_components/sip/sip_client/sip_message.py
@@ -33,7 +33,10 @@ class SdpInfo:
     audio_port: int = 0
     pcmu_pt: int = -1
     pcma_pt: int = -1
+    g722_pt: int = -1
     telephone_event_pt: int = -1
+    # All payload types seen on m=audio or a=rtpmap (audio + telephone-event).
+    offered_pts: set[int] = field(default_factory=set)
 
 
 # Compact header mapping (RFC 3261 Section 7.3.3)
@@ -126,15 +129,23 @@ def parse_sdp(body: str) -> SdpInfo:
                 except ValueError:
                     info.audio_port = 0
             pts = tokens[2:] if len(tokens) > 2 else []
+            for tok in pts:
+                try:
+                    info.offered_pts.add(int(tok))
+                except ValueError:
+                    continue
             if "0" in pts:
                 info.pcmu_pt = 0
             if "8" in pts:
                 info.pcma_pt = 8
+            if "9" in pts:
+                info.g722_pt = 9
         elif line.startswith("a=rtpmap:"):
             m = re.match(r"a=rtpmap:(\d+)", line)
             if not m:
                 continue
             pt = int(m.group(1))
+            info.offered_pts.add(pt)
             lower = line.lower()
             if "telephone-event" in lower:
                 info.telephone_event_pt = pt
@@ -142,6 +153,8 @@ def parse_sdp(body: str) -> SdpInfo:
                 info.pcmu_pt = pt
             elif "pcma" in lower:
                 info.pcma_pt = pt
+            elif "g722" in lower:
+                info.g722_pt = pt
     return info
 
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -40,6 +40,8 @@ def _load_pkg_module(name):
     return mod
 
 
+g722 = _load_pkg_module("g722")
+codecs = _load_pkg_module("codecs")
 rtp_session = _load_pkg_module("rtp_session")
 try:
     sip_client = _load_pkg_module("sip_client")
@@ -117,6 +119,93 @@ def test_parse_sdp():
     assert sdp.pcmu_pt == 0
     assert sdp.pcma_pt == 8
     assert sdp.telephone_event_pt == 101
+    assert sdp.offered_pts == {0, 8, 101}
+
+
+def test_parse_sdp_offered_pts_from_rtpmap_only():
+    # Dynamic PT advertised only via rtpmap still lands in offered_pts.
+    body = (
+        "m=audio 4002 RTP/AVP 96 97\r\n"
+        "a=rtpmap:96 PCMU/8000\r\n"
+        "a=rtpmap:97 telephone-event/8000\r\n"
+    )
+    sdp = sm.parse_sdp(body)
+    assert sdp.offered_pts == {96, 97}
+    assert sdp.pcmu_pt == 96
+    assert sdp.telephone_event_pt == 97
+
+
+# -------------------------------------------------------------- codecs
+def _sdp(pts, *, pcmu=-1, pcma=-1, g722=-1):
+    info = sm.SdpInfo(offered_pts=set(pts), pcmu_pt=pcmu, pcma_pt=pcma, g722_pt=g722)
+    return info
+
+
+def test_codecs_choose_preference():
+    assert codecs.choose(_sdp({9, 0, 8}, pcmu=0, pcma=8, g722=9)).payload_type == 9
+    assert codecs.choose(_sdp({0, 8}, pcmu=0, pcma=8)).payload_type == 0
+    assert codecs.choose(_sdp({8}, pcma=8)).payload_type == 8
+    assert codecs.choose(_sdp({101})).payload_type == 0  # default PCMU
+    assert codecs.choose(_sdp(set())).payload_type == 0
+
+
+def test_codecs_choose_dynamic_pt_by_name():
+    # a=rtpmap:96 PCMU/8000 — static PT 0 absent; must bind PCMU to 96.
+    chosen = codecs.choose(_sdp({96, 97}, pcmu=96))
+    assert chosen.name == "PCMU"
+    assert chosen.payload_type == 96
+    chosen = codecs.choose(_sdp({98}, pcma=98))
+    assert chosen.name == "PCMA" and chosen.payload_type == 98
+    chosen = codecs.choose(_sdp({110}, g722=110))
+    assert chosen.name == "G722" and chosen.payload_type == 110
+
+
+def test_codecs_sdp_offer_includes_g722():
+    assert codecs.sdp_media_line(7078) == "m=audio 7078 RTP/AVP 9 0 8 101\r\n"
+    assert codecs.sdp_rtpmaps() == (
+        "a=rtpmap:9 G722/8000\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=rtpmap:8 PCMA/8000\r\n"
+        "a=rtpmap:101 telephone-event/8000\r\n"
+    )
+    # RFC 3551: G.722 rtpmap clock is 8000, not 16000.
+    assert codecs.G722.clock_rate == 8000
+    assert codecs.G722.sample_rate == 16000
+    assert codecs.G722.pcm_frame_bytes == 640
+    assert codecs.G722.ts_increment == 160
+
+
+def test_codecs_sdp_answer_only_negotiated():
+    only = codecs.PCMU
+    assert codecs.sdp_media_line(7078, only=only) == "m=audio 7078 RTP/AVP 0 101\r\n"
+    assert codecs.sdp_rtpmaps(only=only) == (
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=rtpmap:101 telephone-event/8000\r\n"
+    )
+    dyn = codecs.PCMU.with_payload_type(96)
+    assert "96" in codecs.sdp_media_line(7078, only=dyn)
+    assert "PCMU/8000" in codecs.sdp_rtpmaps(only=dyn)
+
+
+def test_local_sdp_offer_and_answer():
+    if sip_client is None:
+        return
+
+    async def run():
+        cfg = sip_client.SipConfig(server="pbx.example", local_rtp_port=7078)
+        client = sip_client.SipClient(cfg)
+        client._local_ip = "192.0.2.1"
+        offer = client._local_sdp()
+        client._codec = codecs.PCMU
+        answer = client._local_sdp(only=client.codec)
+        return offer, answer
+
+    offer, answer = asyncio.run(run())
+    assert "RTP/AVP 9 0 8 101" in offer
+    assert "a=rtpmap:9 G722/8000" in offer
+    assert "RTP/AVP 0 101" in answer
+    assert "G722" not in answer
+    assert "PCMA" not in answer
 
 
 def test_auth_param():
@@ -249,6 +338,219 @@ def test_rfc2833_rx_does_not_swallow_audio():
     audio = asyncio.run(run())
     # 160 bytes of G.711 decode to 160 16-bit samples.
     assert len(audio) == 1 and len(audio[0]) == 320
+
+
+# ---------------------------------------------- rate-aware RTP (Stage 2)
+class _FakeTransport:
+    def __init__(self):
+        self.packets = []
+
+    def sendto(self, packet, addr):
+        self.packets.append(packet)
+
+
+def test_rtp_pcmu_frame_size_and_timestamp():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.set_codec(codecs.PCMU)
+        session._transport = _FakeTransport()
+        session.set_remote("127.0.0.1", 4000)
+        session._timestamp = 1000
+        session._seq = 1
+        session._first_packet = False
+        assert session._pcm_frame_bytes == 320
+        assert session._ts_increment == 160
+        assert len(session._silence_frame()) == 320
+
+        frame = struct.pack("<160h", *([0] * 160))
+        session._send_audio_packet(frame)
+        session._send_audio_packet(frame)
+        return session._transport.packets, session._timestamp
+
+    packets, ts = asyncio.run(run())
+    assert len(packets) == 2
+    # 12-byte RTP header + 160-byte G.711 payload
+    assert all(len(p) == 172 for p in packets)
+    assert packets[0][1] & 0x7F == 0  # PCMU
+    ts0 = int.from_bytes(packets[0][4:8], "big")
+    ts1 = int.from_bytes(packets[1][4:8], "big")
+    assert ts1 - ts0 == 160
+    assert ts == 1000 + 320
+
+
+def test_rtp_set_codec_resets_encoder():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.set_codec(codecs.PCMA)
+        assert session.payload_type == 8
+        assert session._pcm_frame_bytes == 320
+        assert session._ts_increment == 160
+        # Encode path uses the session encoder (PCMA).
+        session._transport = _FakeTransport()
+        session.set_remote("127.0.0.1", 4000)
+        session._timestamp = 0
+        session._first_packet = False
+        session._send_audio_packet(b"\x00" * 320)
+        return session._transport.packets[0]
+
+    pkt = asyncio.run(run())
+    assert pkt[1] & 0x7F == 8
+
+
+def test_rtp_decoder_cache_reuses_stateful_decoder():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.set_codec(codecs.G722)
+        # Off-PT G.711 packet still gets a cached decoder (not recreated).
+        d1 = session._decoder_for(0)
+        d2 = session._decoder_for(0)
+        assert d1 is d2
+        assert session._decoder_for(9) is session._decode
+        return True
+
+    assert asyncio.run(run())
+
+
+def test_rtp_g722_frame_size_and_timestamp():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.set_codec(codecs.G722)
+        session._transport = _FakeTransport()
+        session.set_remote("127.0.0.1", 4000)
+        session._timestamp = 5000
+        session._first_packet = False
+        assert session._pcm_frame_bytes == 640
+        assert session._ts_increment == 160
+        assert len(session._silence_frame()) == 640
+
+        frame = b"\x00" * 640
+        session._send_audio_packet(frame)
+        session._send_audio_packet(frame)
+        return session._transport.packets
+
+    packets = asyncio.run(run())
+    assert all(len(p) == 172 for p in packets)  # 12 + 160 payload
+    assert packets[0][1] & 0x7F == 9
+    ts0 = int.from_bytes(packets[0][4:8], "big")
+    ts1 = int.from_bytes(packets[1][4:8], "big")
+    assert ts1 - ts0 == 160  # RFC 3551 clock quirk
+
+
+# --------------------------------------------------------------- g722
+def test_g722_frame_lengths():
+    pcm = struct.pack("<320h", *([1000] * 320))
+    enc = g722.G722Encoder()
+    dec = g722.G722Decoder()
+    payload = enc.encode(pcm)
+    assert len(payload) == 160
+    out = dec.decode(payload)
+    assert len(out) == 640
+
+
+def test_g722_bitexact_reference_vectors():
+    """Pin encode output against sippy/libg722 (ITU-verified) reference frames.
+
+    Fixtures were cross-checked with the PyPI ``G722`` C extension on the same
+    PCM inputs (silence → 440 Hz tone → full-scale square), stateful across
+    frames. A table typo will fail this test even if correlation still looks ok.
+    """
+    import math
+
+    sr = 16000
+    n = 320
+    silence = struct.pack("<320h", *([0] * n))
+    tone = struct.pack(
+        "<320h",
+        *[int(10000 * math.sin(2 * math.pi * 440 * i / sr)) for i in range(n)],
+    )
+    square = struct.pack(
+        "<320h",
+        *[32000 if (i // 40) % 2 == 0 else -32000 for i in range(n)],
+    )
+    # Full 160-byte reference payloads (hex), stateful encode of silence→tone→square.
+    ref = [
+        bytes.fromhex(
+            "fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa"
+            "fafafafafafafafafafafafaf7f7f7f7f7f7f7f8f7faf7f8f8fafaf7f7f8f7fa"
+            "f8f7faf8f7faf7f8f8fadbf0f8f8f8f8fadbf1f8f8fafaf8def3faf8f8fafa"
+            "def0fafaf8f8fadbf1fafaf8f8fadcf2faf8f8fafadef0fafaf8f8fad8f3fa"
+            "f8f8fadef3faf8f8fadef3faf8f8fadef2faf8f8fadef2faf8f8fadef2faf8"
+            "f8fade"
+        ),
+        bytes.fromhex(
+            "f2992688228ca0a060a8d8d6d99454dbb17ed59d5effbdecea7af9f9dfdbdeb8"
+            "5bd75a95559bf5f5b6f3f674f5b576fffed7d9d3d9d6d9ddde77bcf0aff9eeb6"
+            "77fedddfd7985298d5d8debb78f3b46ef4f0f2dff7d7fe53d895d49addfdfab6"
+            "73f4edb4f2fbdff9d75bd696d79adc9a75b6f8eef5f0f27bfcbbd7dd5493fed1"
+            "5bbadef6b6f2f46fb9f4f65abdd85496d9d6dbfddff5b7f772b2f4f3dc7fdfdc"
+        ),
+        bytes.fromhex(
+            "923f89248420a0049f2ab7fd76777ef973fff6f73db43094228404a0268bd339"
+            "df5edcdd5dd8da7cdd1b98308520a004caab6d745ef75c5ef2fbfa7b7db83191"
+            "228404e0e5538d5976597dfbd8dbff5c5b3898328520a04449f268ed587dfcfb"
+            "fb7a74f87b9e3094228404e0e6548c567bd87a7adadc577adb3a96308720a0c5"
+            "4ef96c6c78f8fedbf475777d78b83494228404e1a95f50515f5efbdf7cddd77f"
+        ),
+    ]
+    enc = g722.G722Encoder()
+    for pcm, expected in zip((silence, tone, square), ref):
+        assert enc.encode(pcm) == expected
+
+    # Decode path: same payloads through a fresh decoder must match reference PCM
+    # prefixes (first 16 samples of each frame) from the C implementation.
+    dec_ref_prefix = [
+        bytes.fromhex("0000ffffffff00000000ffff00000000ffffffff000001000200020001000100"),
+        bytes.fromhex("0100010001000000ffffffff000002000100fdfffeff0300fdfff2fffbff1600"),
+        bytes.fromhex("dc24932628278926c324eb21101e3d19da130b0e4d07baff05fa42f5d5ecdee3"),
+    ]
+    dec = g722.G722Decoder()
+    for payload, prefix in zip(ref, dec_ref_prefix):
+        out = dec.decode(payload)
+        assert out[:32] == prefix
+
+
+def test_g722_roundtrip_correlates():
+    import math
+
+    sr = 16000
+    n = 320 * 20  # 400 ms
+    samples = [int(8000 * math.sin(2 * math.pi * 440 * i / sr)) for i in range(n)]
+    pcm = struct.pack("<%dh" % n, *samples)
+    enc = g722.G722Encoder()
+    dec = g722.G722Decoder()
+    # Encode/decode in 20 ms frames to exercise state continuity.
+    out = bytearray()
+    for off in range(0, len(pcm), 640):
+        out.extend(dec.decode(enc.encode(pcm[off : off + 640])))
+    out_s = struct.unpack("<%dh" % (len(out) // 2), out)
+    # The transmit+receive QMF pair delays by ~22 samples; align before correlating.
+    qmf_delay = 22
+    a = samples[640 : 640 + 4000]
+    b = out_s[640 + qmf_delay : 640 + qmf_delay + 4000]
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    corr = dot / (na * nb)
+    assert corr > 0.95, corr
+
+
+def test_g722_perf_under_budget():
+    import math
+    import time
+
+    samples = [int(8000 * math.sin(2 * math.pi * 440 * i / 16000)) for i in range(320)]
+    pcm = struct.pack("<320h", *samples)
+    enc = g722.G722Encoder()
+    dec = g722.G722Decoder()
+    for _ in range(5):
+        dec.decode(enc.encode(pcm))
+    t0 = time.perf_counter()
+    n = 50
+    for _ in range(n):
+        dec.decode(enc.encode(pcm))
+    us = (time.perf_counter() - t0) / n * 1e6
+    # Soft budget: must stay well inside the 20 ms frame (headroom for Pi).
+    assert us < 15000, f"encode+decode took {us:.0f} µs/frame"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a pure-Python G.722 (64 kbit/s) codec and a codec registry so SDP offer/answer, payload selection, and RTP encode/decode share one source of truth
- Negotiate G.722 first when the peer offers it (FreePBX/Asterisk/etc.), with automatic G.711 µ-law/A-law fallback; Assist and recording use the negotiated sample rate (true 16 kHz on G.722)
- Keep RFC 3551 clock quirk (`G722/8000`, timestamp +160), RFC 3264 single-codec answers, dynamic-PT name fallback, and DTMF paths unchanged

## Test plan
- [ ] `python3 -m pytest tests/test_pure.py -q` (includes G.722 bit-exact reference vectors)
- [ ] Outbound call to a G.722-capable FreePBX extension: SDP offers `9 0 8 101`, call negotiates PT 9, audio clear both ways
- [ ] Call to a G.711-only peer: falls back to PCMU/PCMA, answer SDP lists only the chosen codec
- [ ] DTMF (RFC 2833 + SIP INFO) still works on a G.722 call
- [ ] `sip.start_recording` on a G.722 call produces a WAV that plays at normal speed (16 kHz header)
- [ ] Voice Assist on a G.722 call uses 16 kHz PCM without sample-duplication upsample


Made with [Cursor](https://cursor.com)