### PR TITLE
ci: add HACS/hassfest validation and pin ruff lint rules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,20 +10,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint
+        run: python -m ruff check custom_components/
+
   test:
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -34,7 +51,7 @@ jobs:
               pip install -r requirements.txt
             fi
           fi
-          
+
       - name: Run tests
         run: |
           python -m pytest tests/

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: Validate
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  validate-hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .pytest_cache/
+.ruff_cache/
 
 # OS / editor
 .DS_Store

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -42,15 +42,14 @@ from .const import (
 )
 from .helpers import get_ffmpeg_bin
 from .ivr import IvrSession
+from .sip_client.audio import FfmpegAudioSource, NullSink
+from .sip_client.sip_client import SipCallbacks, SipClient, SipConfig, SipState
 
 
 def _sip_device_id(hass: HomeAssistant, entry_id: str) -> str | None:
     """Return the device registry id for a SIP config entry, if created yet."""
     device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, entry_id)})
     return device.id if device else None
-
-from .sip_client.audio import FfmpegAudioSource, NullSink
-from .sip_client.sip_client import SipCallbacks, SipClient, SipConfig, SipState
 
 PLATFORMS = [
     Platform.SENSOR,

--- a/custom_components/sip/config_flow.py
+++ b/custom_components/sip/config_flow.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 import asyncio
-import socket
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -1,21 +1,22 @@
 {
   "domain": "sip",
   "name": "SIP Client",
-  "codeowners": [
-    "@eigger"
-  ],
-  "config_flow": true,
-  "documentation": "https://github.com/eigger/hass-sip",
-  "issue_tracker": "https://github.com/eigger/hass-sip/issues",
-  "integration_type": "hub",
-  "iot_class": "local_push",
-  "dependencies": [
-    "ffmpeg",
-    "tts"
-  ],
   "after_dependencies": [
     "assist_pipeline",
     "stt"
   ],
+  "codeowners": [
+    "@eigger"
+  ],
+  "config_flow": true,
+  "dependencies": [
+    "ffmpeg",
+    "logbook",
+    "tts"
+  ],
+  "documentation": "https://github.com/eigger/hass-sip",
+  "integration_type": "hub",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/eigger/hass-sip/issues",
   "version": "1.8.1"
 }

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -11,7 +11,7 @@ import enum
 import logging
 import socket
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable
 
 from . import codecs

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,13 @@
+# Ruff configuration.
+#
+# CI installs ruff unpinned, so without this file the effective rule set is
+# whatever the latest release happens to enable by default — a ruff upgrade can
+# turn a green branch red without any code change. Pin the selection here
+# instead: E/F are the pycodestyle+pyflakes rules this codebase was already
+# clean against (real errors: undefined names, unused imports, syntax issues).
+[lint]
+select = ["E", "F"]
+
+# Long lines are common in SIP/SDP strings and log-message formatting and
+# are not worth churning; everything else in E/F stays enforced.
+ignore = ["E501"]


### PR DESCRIPTION
## Summary
- HACS Action과 Hassfest 검증 워크플로를 추가합니다 (`validate.yml`).
- Tests 워크플로에 ruff lint job을 넣고, `ruff.toml`에서 E/F 규칙만 고정합니다.
- hassfest 통과를 위해 manifest 키를 정렬하고 `logbook` dependency를 선언하며, ruff E/F 위반(미사용 import, import 위치)을 수정합니다.

## Test plan
- [ ] GitHub Actions `Validate` (HACS + Hassfest)가 이 PR에서 통과하는지 확인
- [ ] GitHub Actions `Tests`의 lint job과 Python 3.12/3.13/3.14 테스트가 통과하는지 확인
- [ ] 로컬: `python -m ruff check custom_components/` 및 `python -m pytest tests/` 통과 확인


Made with [Cursor](https://cursor.com)