### PR TITLE
refactor(assist): unify TX wait state and dedupe paced PCM sources

### DIFF
--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -425,6 +425,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             noise_suppression=noise_suppression,
             turn_tone=turn_tone,
             stop_audio_fn=client.stop_audio,
+            media_playing_fn=lambda: client.media_playing,
         )
 
         def on_assist_done() -> None:

--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -119,6 +119,7 @@ class AssistBridge(AudioSink):
         noise_suppression: int = 0,
         turn_tone: bool = False,
         stop_audio_fn: Callable[..., None] | None = None,
+        media_playing_fn: Callable[[], bool] | None = None,
     ) -> None:
         """Initialize the Assist bridge."""
         self.hass = hass
@@ -133,6 +134,7 @@ class AssistBridge(AudioSink):
         self.noise_suppression = noise_suppression
         self.turn_tone = turn_tone
         self.stop_audio_fn = stop_audio_fn
+        self.media_playing_fn = media_playing_fn
 
         if barge_in and MicroVad is None:
             LOGGER.warning(
@@ -219,6 +221,18 @@ class AssistBridge(AudioSink):
         self._background_tasks.clear()
         if stop_audio and self.stop_audio_fn:
             self.stop_audio_fn(flush=True)
+
+    async def _wait_for_tx_idle(self) -> None:
+        """Wait until the SIP client is no longer transmitting audio.
+
+        ``play_source()`` cancels any in-flight TX, so callers must not start
+        a new source (turn tone, TTS, etc.) while the previous response is
+        still draining through RTP.
+        """
+        if self.media_playing_fn is None:
+            return
+        while self._running and self.media_playing_fn():
+            await asyncio.sleep(0.02)
 
     def _monitor_barge_in(self, pcm_le: bytes) -> None:
         """Detect caller speech during TTS playback and trigger barge-in."""
@@ -420,6 +434,9 @@ class AssistBridge(AudioSink):
         self._tone_capture = bytearray()
         timed_out = False
         try:
+            await self._wait_for_tx_idle()
+            if not self._running:
+                return b""
             self.play_source(ToneAudioSource())
             try:
                 async with asyncio.timeout(3):
@@ -452,6 +469,7 @@ class AssistBridge(AudioSink):
             # RTP keeps playing — flushing there would cut long responses.
             if self._background_tasks:
                 self._cancel_inflight_tts(stop_audio=True)
+        await self._wait_for_tx_idle()
         ended_by_barge_in = self._post_barge_in_capture
         self._tx_done.clear()
         self._tx_wait = None
@@ -521,6 +539,9 @@ class AssistBridge(AudioSink):
 
             wav_data = b"".join(chunks)
             source = FfmpegAudioSource(data=wav_data, ffmpeg_bin=get_ffmpeg_bin(self.hass))
+            await self._wait_for_tx_idle()
+            if epoch != self._tts_epoch:
+                return
             self.play_source(source)
         except Exception as err:
             LOGGER.exception("Error playing Assist TTS response: %s", err)

--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterable, Callable
+from typing import Literal
 
 from homeassistant.components import tts
 from homeassistant.components.assist_pipeline import (
@@ -39,6 +40,7 @@ _VAD_FRAME_BYTES = 320  # 10 ms @ 16 kHz s16le mono
 _VAD_SPEECH_THRESHOLD = 0.5
 _VAD_MIN_SPEECH_FRAMES = 30  # 300 ms consecutive speech
 _PREROLL_MAX_BYTES = 16000  # 500 ms @ 16 kHz s16le mono
+_TxWaitKind = Literal["tts", "tone"]
 
 
 def _upsample_pcm(pcm_le: bytes, sample_rate: int) -> bytes:
@@ -143,9 +145,8 @@ class AssistBridge(AudioSink):
         self._running = True
         self._listening = False
         self._speaking = False
-        self._playback_done = asyncio.Event()
-        self._tone_done: asyncio.Event | None = None
-        self._awaiting_tone = False
+        self._tx_done = asyncio.Event()
+        self._tx_wait: _TxWaitKind | None = None
         self._conversation_id: str | None = None
         self._turn_error: str | None = None
         self._turn_index = 0
@@ -168,7 +169,7 @@ class AssistBridge(AudioSink):
         """Receive incoming PCM from SIP client and feed it to Assist."""
         if self._listening:
             self.audio_stream.feed_audio(pcm_le, self.sample_rate)
-        elif self._awaiting_tone:
+        elif self._tx_wait == "tone":
             self._append_tone_capture(_upsample_pcm(pcm_le, self.sample_rate))
         elif self._post_barge_in_capture:
             self._append_rx_to_ring(_upsample_pcm(pcm_le, self.sample_rate))
@@ -178,13 +179,11 @@ class AssistBridge(AudioSink):
     def on_playback_done(self) -> None:
         """Signal that TX playback has finished (see IvrSession for the same pattern).
 
-        Turn-start tone completion must not set ``_playback_done``: that event
-        is reserved for TTS wait and would otherwise open the mic mid-response.
+        Only the waiter registered in ``_tx_wait`` is released so turn-start tone
+        completion cannot unblock a TTS wait (and vice versa).
         """
-        if self._awaiting_tone and self._tone_done is not None:
-            self._tone_done.set()
-            return
-        self._playback_done.set()
+        if self._tx_wait is not None:
+            self._tx_done.set()
 
     def close(self) -> None:
         """Stop the bridge and cancel running tasks."""
@@ -193,9 +192,8 @@ class AssistBridge(AudioSink):
         self._speaking = False
         self._post_barge_in_capture = False
         self._cancel_inflight_tts()
-        self._playback_done.set()
-        if self._tone_done is not None:
-            self._tone_done.set()
+        self._tx_wait = None
+        self._tx_done.set()
         if self.session_task:
             self.session_task.cancel()
             self.session_task = None
@@ -248,7 +246,7 @@ class AssistBridge(AudioSink):
         self._vad_speech_frames = 0
         self._ring_buffer.clear()
         self._post_barge_in_capture = True
-        self._playback_done.set()
+        self._tx_done.set()
 
     def _build_audio_settings(self) -> AudioSettings | None:
         """Return pipeline audio settings, or None to keep Assist defaults.
@@ -417,15 +415,15 @@ class AssistBridge(AudioSink):
         """
         if not self.turn_tone or self.play_source is None:
             return b""
-        self._tone_done = asyncio.Event()
-        self._awaiting_tone = True
+        self._tx_wait = "tone"
+        self._tx_done.clear()
         self._tone_capture = bytearray()
         timed_out = False
         try:
             self.play_source(ToneAudioSource())
             try:
                 async with asyncio.timeout(3):
-                    await self._tone_done.wait()
+                    await self._tx_done.wait()
             except TimeoutError:
                 timed_out = True
                 LOGGER.debug("Assist: turn tone playback-done timeout")
@@ -435,7 +433,7 @@ class AssistBridge(AudioSink):
             LOGGER.exception("Assist: failed to play turn tone")
             timed_out = True
         finally:
-            self._awaiting_tone = False
+            self._tx_wait = None
         if timed_out and self._tone_capture:
             return bytes(self._tone_capture)
         return b""
@@ -446,7 +444,7 @@ class AssistBridge(AudioSink):
             return
         try:
             async with asyncio.timeout(30):
-                await self._playback_done.wait()
+                await self._tx_done.wait()
         except TimeoutError:
             LOGGER.warning("Assist: playback-done timeout; continuing")
             # Only cancel/stop when a TTS fetch task is still in flight. Once
@@ -455,7 +453,8 @@ class AssistBridge(AudioSink):
             if self._background_tasks:
                 self._cancel_inflight_tts(stop_audio=True)
         ended_by_barge_in = self._post_barge_in_capture
-        self._playback_done.clear()
+        self._tx_done.clear()
+        self._tx_wait = None
         self._speaking = False
         if not ended_by_barge_in:
             self._reset_barge_in_state()
@@ -496,7 +495,8 @@ class AssistBridge(AudioSink):
                 and (stream := tts.async_get_stream(self.hass, tts_output["token"]))
             ):
                 self._speaking = True
-                self._playback_done.clear()
+                self._tx_wait = "tts"
+                self._tx_done.clear()
                 self._reset_barge_in_state()
                 self._tts_epoch += 1
                 epoch = self._tts_epoch
@@ -525,4 +525,4 @@ class AssistBridge(AudioSink):
         except Exception as err:
             LOGGER.exception("Error playing Assist TTS response: %s", err)
             if epoch == self._tts_epoch:
-                self._playback_done.set()
+                self._tx_done.set()

--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -40,6 +40,7 @@ _VAD_FRAME_BYTES = 320  # 10 ms @ 16 kHz s16le mono
 _VAD_SPEECH_THRESHOLD = 0.5
 _VAD_MIN_SPEECH_FRAMES = 30  # 300 ms consecutive speech
 _PREROLL_MAX_BYTES = 16000  # 500 ms @ 16 kHz s16le mono
+_TX_IDLE_TIMEOUT_SECONDS = 60.0
 _TxWaitKind = Literal["tts", "tone"]
 
 
@@ -231,8 +232,15 @@ class AssistBridge(AudioSink):
         """
         if self.media_playing_fn is None:
             return
-        while self._running and self.media_playing_fn():
-            await asyncio.sleep(0.02)
+        try:
+            async with asyncio.timeout(_TX_IDLE_TIMEOUT_SECONDS):
+                while self._running and self.media_playing_fn():
+                    await asyncio.sleep(0.02)
+        except TimeoutError:
+            LOGGER.warning(
+                "Assist: TX idle wait timeout after %.0fs; continuing",
+                _TX_IDLE_TIMEOUT_SECONDS,
+            )
 
     def _monitor_barge_in(self, pcm_le: bytes) -> None:
         """Detect caller speech during TTS playback and trigger barge-in."""

--- a/custom_components/sip/sip_client/audio.py
+++ b/custom_components/sip/sip_client/audio.py
@@ -11,10 +11,10 @@ later by implementing the same tiny interfaces, without touching the SIP core.
 """
 from __future__ import annotations
 
-import array
 import asyncio
 import logging
 import math
+import struct
 import wave
 from abc import ABC, abstractmethod
 from typing import Callable
@@ -23,6 +23,13 @@ _LOGGER = logging.getLogger(__name__)
 
 PushFn = Callable[[bytes], None]
 ActiveFn = Callable[[], bool]
+
+_PCM_FRAME_SLEEP = 0.018
+
+
+def default_pcm_frame_bytes(sample_rate: int) -> int:
+    """Return 20 ms of s16le mono PCM at ``sample_rate``."""
+    return sample_rate // 50 * 2
 
 
 class AudioSource(ABC):
@@ -76,7 +83,39 @@ class WavRecorderSink(AudioSink):
             pass
 
 
-class FfmpegAudioSource(AudioSource):
+class _ConfiguredPcmSource(AudioSource):
+    """Shared negotiated-rate / paced-frame helpers for in-process PCM sources."""
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int = 8000,
+        pcm_frame_bytes: int | None = None,
+    ) -> None:
+        self._sample_rate = sample_rate
+        self._pcm_frame_bytes = (
+            pcm_frame_bytes
+            if pcm_frame_bytes is not None
+            else default_pcm_frame_bytes(sample_rate)
+        )
+
+    def configure(self, sample_rate: int, pcm_frame_bytes: int) -> None:
+        """Update output rate to match the negotiated codec."""
+        self._sample_rate = sample_rate
+        self._pcm_frame_bytes = pcm_frame_bytes
+
+    async def _push_paced_pcm(
+        self, push: PushFn, is_active: ActiveFn, pcm: bytes
+    ) -> None:
+        offset = 0
+        frame = self._pcm_frame_bytes
+        while is_active() and offset < len(pcm):
+            push(pcm[offset : offset + frame])
+            offset += frame
+            await asyncio.sleep(_PCM_FRAME_SLEEP)
+
+
+class FfmpegAudioSource(_ConfiguredPcmSource):
     """Decode any media (file path, URL, or raw bytes) to mono PCM via ffmpeg.
 
     ffmpeg transparently handles WAV/MP3/etc. and produces the exact format the
@@ -97,20 +136,12 @@ class FfmpegAudioSource(AudioSource):
         sample_rate: int = 8000,
         pcm_frame_bytes: int | None = None,
     ) -> None:
+        super().__init__(sample_rate=sample_rate, pcm_frame_bytes=pcm_frame_bytes)
         if (url is None) == (data is None):
             raise ValueError("Provide exactly one of url/data")
         self._bin = ffmpeg_bin
         self._url = url
         self._data = data
-        self._sample_rate = sample_rate
-        self._pcm_frame_bytes = (
-            pcm_frame_bytes if pcm_frame_bytes is not None else sample_rate // 50 * 2
-        )
-
-    def configure(self, sample_rate: int, pcm_frame_bytes: int) -> None:
-        """Update output rate to match the negotiated codec."""
-        self._sample_rate = sample_rate
-        self._pcm_frame_bytes = pcm_frame_bytes
 
     async def run(self, push: PushFn, is_active: ActiveFn) -> None:
         src = self._url if self._url is not None else "pipe:0"
@@ -145,7 +176,7 @@ class FfmpegAudioSource(AudioSource):
                 if not chunk:
                     break
                 push(chunk)
-                await asyncio.sleep(0.018)
+                await asyncio.sleep(_PCM_FRAME_SLEEP)
         finally:
             if proc.returncode is None:
                 try:
@@ -155,7 +186,46 @@ class FfmpegAudioSource(AudioSource):
             await proc.wait()
 
 
-class ToneAudioSource(AudioSource):
+_TONE_PCM_CACHE: dict[tuple[int, int, int, float, int], bytes] = {}
+
+
+def _render_tone_pcm(
+    *,
+    sample_rate: int,
+    freq_hz: int,
+    duration_ms: int,
+    amplitude: float,
+    fade_ms: int,
+) -> bytes:
+    key = (sample_rate, freq_hz, duration_ms, amplitude, fade_ms)
+    cached = _TONE_PCM_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    n_samples = int(sample_rate * duration_ms / 1000)
+    if n_samples <= 0:
+        return b""
+
+    fade_samples = min(int(sample_rate * fade_ms / 1000), n_samples // 2)
+    peak = int(amplitude * 32767)
+    omega = 2.0 * math.pi * freq_hz / sample_rate
+    buf = bytearray(n_samples * 2)
+    last = n_samples - 1
+    for i in range(n_samples):
+        env = 1.0
+        if fade_samples > 0:
+            if i < fade_samples:
+                env = i / fade_samples
+            elif i > last - fade_samples:
+                env = (last - i) / fade_samples
+        struct.pack_into("<h", buf, i * 2, int(peak * env * math.sin(omega * i)))
+
+    pcm = bytes(buf)
+    _TONE_PCM_CACHE[key] = pcm
+    return pcm
+
+
+class ToneAudioSource(_ConfiguredPcmSource):
     """Generate a short sine burst for RTP TX without ffmpeg.
 
     A fade in/out is applied so the burst does not click on codecs that
@@ -172,47 +242,20 @@ class ToneAudioSource(AudioSource):
         sample_rate: int = 8000,
         pcm_frame_bytes: int | None = None,
     ) -> None:
+        super().__init__(sample_rate=sample_rate, pcm_frame_bytes=pcm_frame_bytes)
         self._freq_hz = freq_hz
         self._duration_ms = duration_ms
         self._amplitude = amplitude
         self._fade_ms = fade_ms
-        self._sample_rate = sample_rate
-        self._pcm_frame_bytes = (
-            pcm_frame_bytes if pcm_frame_bytes is not None else sample_rate // 50 * 2
-        )
-
-    def configure(self, sample_rate: int, pcm_frame_bytes: int) -> None:
-        """Update output rate to match the negotiated codec."""
-        self._sample_rate = sample_rate
-        self._pcm_frame_bytes = pcm_frame_bytes
 
     def _render_pcm(self) -> bytes:
-        n_samples = int(self._sample_rate * self._duration_ms / 1000)
-        if n_samples <= 0:
-            return b""
-        fade_samples = min(
-            int(self._sample_rate * self._fade_ms / 1000),
-            n_samples // 2,
+        return _render_tone_pcm(
+            sample_rate=self._sample_rate,
+            freq_hz=self._freq_hz,
+            duration_ms=self._duration_ms,
+            amplitude=self._amplitude,
+            fade_ms=self._fade_ms,
         )
-        peak = int(self._amplitude * 32767)
-        omega = 2.0 * math.pi * self._freq_hz / self._sample_rate
-        samples = array.array("h")
-        last = n_samples - 1
-        for i in range(n_samples):
-            env = 1.0
-            if fade_samples > 0:
-                if i < fade_samples:
-                    env = i / fade_samples
-                elif i > last - fade_samples:
-                    env = (last - i) / fade_samples
-            samples.append(int(peak * env * math.sin(omega * i)))
-        return samples.tobytes()
 
     async def run(self, push: PushFn, is_active: ActiveFn) -> None:
-        pcm = self._render_pcm()
-        offset = 0
-        frame = self._pcm_frame_bytes
-        while is_active() and offset < len(pcm):
-            push(pcm[offset : offset + frame])
-            offset += frame
-            await asyncio.sleep(0.018)
+        await self._push_paced_pcm(push, is_active, self._render_pcm())

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1032,6 +1032,24 @@ def test_assist_turn_tone_defers_until_media_idle():
     assert play_calls == ["ToneAudioSource"]
 
 
+def test_assist_wait_for_tx_idle_times_out():
+    assist_mod, _, _, _ = _assist_ctx()
+
+    async def run():
+        bridge = assist_mod.AssistBridge(
+            MagicMock(),
+            play_source_fn=MagicMock(),
+            on_done_fn=MagicMock(),
+            media_playing_fn=lambda: True,
+        )
+        t0 = asyncio.get_running_loop().time()
+        with patch.object(assist_mod, "_TX_IDLE_TIMEOUT_SECONDS", 0.05):
+            await bridge._wait_for_tx_idle()
+        assert asyncio.get_running_loop().time() - t0 < 1.0
+
+    asyncio.run(run())
+
+
 def test_assist_close_during_session():
     assist_mod, mock_ap, PET, PE = _assist_ctx()
     done_calls = []

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -146,6 +146,21 @@ def test_tone_audio_source_byte_count_and_fade():
     assert max(abs(s) for s in samples16) > 1000
 
 
+def test_tone_pcm_cache_reuses_rendered_bytes():
+    audio._TONE_PCM_CACHE.clear()
+    kwargs = {
+        "sample_rate": 8000,
+        "freq_hz": 880,
+        "duration_ms": 120,
+        "amplitude": 0.25,
+        "fade_ms": 10,
+    }
+    first = audio._render_tone_pcm(**kwargs)
+    second = audio._render_tone_pcm(**kwargs)
+    assert first is second
+    audio._TONE_PCM_CACHE.clear()
+
+
 # ------------------------------------------------------------ sip_message
 def test_parse_response():
     raw = (
@@ -852,7 +867,8 @@ def test_assist_playback_done_unblocks_next_turn():
         bridge.start()
         await asyncio.sleep(0.05)
         bridge._speaking = True
-        bridge._playback_done.clear()
+        bridge._tx_wait = "tts"
+        bridge._tx_done.clear()
         bridge.on_playback_done()
         if bridge.session_task:
             await bridge.session_task
@@ -1089,8 +1105,6 @@ def test_assist_tts_failure_signals_playback_done():
     failing_stream.async_stream_result = failing_result
     mock_tts.async_get_stream.return_value = failing_stream
 
-    playback_done = asyncio.Event()
-
     async def mock_pipeline(hass, **kwargs):
         cb = kwargs["event_callback"]
         cb(PE(PET.TTS_END, {"tts_output": {"token": "tok"}}))
@@ -1103,12 +1117,11 @@ def test_assist_tts_failure_signals_playback_done():
         on_done_fn=MagicMock(),
         max_turns=1,
     )
-    bridge._playback_done = playback_done
 
     async def run():
         bridge.start()
-        await asyncio.wait_for(playback_done.wait(), timeout=2)
-        assert playback_done.is_set()
+        await asyncio.wait_for(bridge._tx_done.wait(), timeout=2)
+        assert bridge._tx_done.is_set()
         if bridge.session_task:
             await bridge.session_task
 
@@ -1144,7 +1157,7 @@ def test_assist_barge_in_triggers_stop_and_preroll():
             bridge.write(frame)
         assert stop_calls == [True]
         assert bridge._barge_in_preroll
-        assert bridge._playback_done.is_set()
+        assert bridge._tx_done.is_set()
         assert bridge._post_barge_in_capture
     finally:
         assist_mod._VAD_MIN_SPEECH_FRAMES = original_min
@@ -1400,16 +1413,34 @@ def test_assist_turn_tone_playback_done_does_not_set_tts_event():
         on_done_fn=MagicMock(),
         turn_tone=True,
     )
-    bridge._awaiting_tone = True
-    bridge._tone_done = asyncio.Event()
-    assert not bridge._playback_done.is_set()
+    bridge._tx_wait = "tone"
+    bridge._tx_done.clear()
     bridge.on_playback_done()
-    assert bridge._tone_done.is_set()
-    assert not bridge._playback_done.is_set()
+    assert bridge._tx_done.is_set()
 
-    bridge._awaiting_tone = False
+    bridge._tx_wait = "tts"
+    bridge._tx_done.clear()
     bridge.on_playback_done()
-    assert bridge._playback_done.is_set()
+    assert bridge._tx_done.is_set()
+
+    bridge._tx_wait = None
+    bridge._tx_done.clear()
+    bridge.on_playback_done()
+    assert not bridge._tx_done.is_set()
+
+
+def test_assist_stale_tone_done_ignored_after_wait_cleared():
+    assist_mod, _, _, _ = _assist_ctx()
+    bridge = assist_mod.AssistBridge(
+        MagicMock(),
+        play_source_fn=MagicMock(),
+        on_done_fn=MagicMock(),
+        turn_tone=True,
+    )
+    bridge._tx_wait = None
+    bridge._tx_done.clear()
+    bridge.on_playback_done()
+    assert not bridge._tx_done.is_set()
 
 
 def test_assist_turn_tone_listening_after_playback_done():
@@ -1438,7 +1469,7 @@ def test_assist_turn_tone_listening_after_playback_done():
         bridge.start()
         await asyncio.sleep(0.05)
         assert bridge._listening is False
-        assert bridge._awaiting_tone is True
+        assert bridge._tx_wait == "tone"
         assert play_calls
         assert type(play_calls[0]).__name__ == "ToneAudioSource"
         bridge.on_playback_done()
@@ -1613,7 +1644,7 @@ def test_assist_close_unblocks_turn_tone_wait():
         bridge.start()
         task = bridge.session_task
         await asyncio.sleep(0.05)
-        assert bridge._awaiting_tone is True
+        assert bridge._tx_wait == "tone"
         t0 = asyncio.get_running_loop().time()
         bridge.close()
         try:

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -972,6 +972,66 @@ def test_assist_playback_timeout_does_not_stop_long_playback():
     asyncio.run(run())
 
 
+def test_assist_wait_playback_done_waits_for_media_idle():
+    assist_mod, _, _, _ = _assist_ctx()
+    polls: list[int] = []
+    media_state = {"playing": True}
+
+    def media_fn() -> bool:
+        polls.append(1)
+        if len(polls) >= 3:
+            media_state["playing"] = False
+        return media_state["playing"]
+
+    async def run():
+        bridge = assist_mod.AssistBridge(
+            MagicMock(),
+            play_source_fn=MagicMock(),
+            on_done_fn=MagicMock(),
+            media_playing_fn=media_fn,
+        )
+        bridge._speaking = True
+        bridge._tx_wait = "tts"
+        bridge._tx_done.set()
+        await bridge._wait_playback_done()
+        assert len(polls) >= 3
+        assert bridge._speaking is False
+
+    asyncio.run(run())
+
+
+def test_assist_turn_tone_defers_until_media_idle():
+    assist_mod, mock_ap, PET, PE = _assist_ctx()
+    play_calls: list[str] = []
+    media_state = {"playing": True}
+
+    async def mock_pipeline(hass, **kwargs):
+        kwargs["event_callback"](PE(PET.ERROR, {"code": "stt-no-text-recognized"}))
+
+    mock_ap.async_pipeline_from_audio_stream.side_effect = mock_pipeline
+
+    bridge = assist_mod.AssistBridge(
+        MagicMock(),
+        play_source_fn=lambda src: play_calls.append(type(src).__name__),
+        on_done_fn=MagicMock(),
+        max_silent_turns=1,
+        turn_tone=True,
+        media_playing_fn=lambda: media_state["playing"],
+    )
+
+    async def run():
+        bridge.start()
+        await asyncio.sleep(0.05)
+        assert not play_calls
+        media_state["playing"] = False
+        bridge.on_playback_done()
+        if bridge.session_task:
+            await bridge.session_task
+
+    asyncio.run(run())
+    assert play_calls == ["ToneAudioSource"]
+
+
 def test_assist_close_during_session():
     assist_mod, mock_ap, PET, PE = _assist_ctx()
     done_calls = []


### PR DESCRIPTION
## Summary
- PR #34 머지 후 남았던 정리·하드닝 항목을 한 PR로 처리합니다.
- TTS/신호음 대기를 `_tx_wait` + `_tx_done` 단일 메커니즘으로 통합해, 타임아웃 뒤 늦게 도착하는 tone `on_playback_done`이 TTS 대기를 깨우지 않도록 했습니다.
- `ToneAudioSource` / `FfmpegAudioSource`의 configure·페이싱 로직을 `_ConfiguredPcmSource`로 공유하고, tone PCM은 캐시 + `struct.pack_into(<h)`로 LE 보장합니다.

## 포함 (리뷰 6건 중)
- altitude / simplification: `_playback_done` + `_tone_done` + `_awaiting_tone` → `_tx_wait` + `_tx_done`
- efficiency: `_TONE_PCM_CACHE`
- reuse: `_ConfiguredPcmSource`, `_push_paced_pcm`
- stop_audio_fn=None 갭: `_tx_wait` 클리어 후 stale `on_playback_done` 무시
- endian: explicit little-endian sample packing

## Test plan
- [x] `python -m pytest tests/test_pure.py -q` (71 passed)
- [x] `python -m ruff check custom_components/sip tests`
- [ ] G.711 실기: turn_tone ON/OFF, barge-in, 긴 TTS 응답(30초+) 회귀 없음

Made with [Cursor](https://cursor.com)