### PR TITLE
fix(assist): raise TTS wait timeout to cover real playback lengths

### DIFF
--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -41,6 +41,11 @@ _VAD_SPEECH_THRESHOLD = 0.5
 _VAD_MIN_SPEECH_FRAMES = 30  # 300 ms consecutive speech
 _PREROLL_MAX_BYTES = 16000  # 500 ms @ 16 kHz s16le mono
 _TX_IDLE_TIMEOUT_SECONDS = 60.0
+_TONE_WAIT_TIMEOUT_SECONDS = 3
+# Real-time playback of an LLM-generated response can legitimately run past a
+# minute; this is a safety net for a lost on_playback_done signal, not a
+# normal-case ceiling, so it stays generous.
+_TTS_WAIT_TIMEOUT_SECONDS = 300
 _TxWaitKind = Literal["tts", "tone"]
 
 
@@ -447,7 +452,7 @@ class AssistBridge(AudioSink):
                 return b""
             self.play_source(ToneAudioSource())
             try:
-                async with asyncio.timeout(3):
+                async with asyncio.timeout(_TONE_WAIT_TIMEOUT_SECONDS):
                     await self._tx_done.wait()
             except TimeoutError:
                 timed_out = True
@@ -468,7 +473,7 @@ class AssistBridge(AudioSink):
         if not self._speaking:
             return
         try:
-            async with asyncio.timeout(30):
+            async with asyncio.timeout(_TTS_WAIT_TIMEOUT_SECONDS):
                 await self._tx_done.wait()
         except TimeoutError:
             LOGGER.warning("Assist: playback-done timeout; continuing")

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -972,6 +972,14 @@ def test_assist_playback_timeout_does_not_stop_long_playback():
     asyncio.run(run())
 
 
+def test_assist_tts_wait_timeout_is_generous():
+    """Real calls play 39-52s responses; the safety-net timeout must clear that
+    comfortably or every turn logs a spurious warning (seen at the old 30s)."""
+    assist_mod, _, _, _ = _assist_ctx()
+    assert assist_mod._TTS_WAIT_TIMEOUT_SECONDS >= 120
+    assert assist_mod._TONE_WAIT_TIMEOUT_SECONDS == 3
+
+
 def test_assist_wait_playback_done_waits_for_media_idle():
     assist_mod, _, _, _ = _assist_ctx()
     polls: list[int] = []


### PR DESCRIPTION
## Summary

Real-call logs (1.8.1 and 1.9.0-Pre, both provided by a user testing #34/#35) show LLM-generated responses playing back for 39-52s over RTP. The 30s `_wait_playback_done` safety-net timeout therefore fired on **every single turn**, logging a spurious warning each time -- and, before the `_wait_for_tx_idle` fix landed in #35, actually opening the mic onto the tail of the assistant's own still-playing response (the 1.8.1 log shows 14-27s of self-overlap per turn).

`_wait_for_tx_idle` (merged in #35) now does the real "is TX actually done" check before any new `play_source()` call, so this 30s wait only needs to catch a genuinely lost `on_playback_done` signal -- not act as the primary turn-advance mechanism. Raise it well past any realistic response length and name both TX timeouts as constants instead of bare literals.

- `_TONE_WAIT_TIMEOUT_SECONDS = 3` (unchanged value, now named)
- `_TTS_WAIT_TIMEOUT_SECONDS = 300` (was a bare `30`)

## Test plan

- [x] `python -m pytest tests/test_pure.py -q` -- 75 passed (all 74 pre-existing tests pass unchanged; they patch `asyncio.timeout` wholesale or match on the literal `3`, so the constant rename doesn't affect them)
- [x] `python -m ruff check custom_components/sip tests` -- clean
- [x] New test `test_assist_tts_wait_timeout_is_generous` locks in both constants so a future accidental revert to 30s is caught
- [ ] Real call with a long (>30s) TTS response: no spurious "playback-done timeout" warning in the log

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>