### PR TITLE
Fix SIP dialog routing through proxy chains

### DIFF
--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -166,6 +166,7 @@ class SipClient:
         self._outbound = False
         self._invite_auth_tried = False
         self._incoming_invite: sm.SipMessage | None = None
+        self._dialog_routes: list[str] = []
 
         # negotiated media
         self._remote_rtp_ip = ""
@@ -496,6 +497,7 @@ class SipClient:
         self._pending_source = on_connect_source
         self._outbound = True
         self._invite_auth_tried = False
+        self._dialog_routes = []
         self._d_call_id = sm.gen_call_id(self._local_ip)
         self._d_local_tag = sm.gen_tag()
         self._d_branch = sm.gen_branch()
@@ -622,6 +624,8 @@ class SipClient:
         )
         if self._service_routes and 300 <= resp.status_code < 700:
             msg += f"Route: {self._service_routes}\r\n"
+        elif 200 <= resp.status_code < 300:
+            msg += self._dialog_route_header()
 
         msg += (
             f"From: {self._d_local}\r\n"
@@ -698,6 +702,9 @@ class SipClient:
             contact_uri = _angle_uri(m.header("Contact"))
             if contact_uri:
                 self._d_remote_target = contact_uri
+            self._dialog_routes = list(
+                reversed(sm.split_header_values(m.header("Record-Route")))
+            )
             self._apply_remote_sdp(sm.parse_sdp(m.body))
             self._send_raw(self._build_ack(m))
 
@@ -821,6 +828,7 @@ class SipClient:
                 self._d_local += f";tag={self._d_local_tag}"
             self._d_remote = m.header("From")
             self._d_remote_target = _angle_uri(m.header("Contact"))
+            self._dialog_routes = sm.split_header_values(m.header("Record-Route"))
             try:
                 self._d_cseq = int(m.header("CSeq").split()[0])
             except (ValueError, IndexError):
@@ -951,6 +959,7 @@ class SipClient:
             f"{method} {self._d_remote_target} SIP/2.0\r\n"
             f"Via: SIP/2.0/UDP {self._local_ip}:{self._local_port};branch={sm.gen_branch()};rport\r\n"
             "Max-Forwards: 70\r\n"
+            f"{self._dialog_route_header()}"
             f"From: {self._d_local}\r\n"
             f"To: {self._d_remote}\r\n"
             f"Call-ID: {self._d_call_id}\r\n"
@@ -958,6 +967,11 @@ class SipClient:
             f"User-Agent: {USER_AGENT}\r\n"
             "Content-Length: 0\r\n\r\n"
         )
+
+    def _dialog_route_header(self) -> str:
+        if not self._dialog_routes:
+            return ""
+        return f"Route: {', '.join(self._dialog_routes)}\r\n"
 
     def send_dtmf(self, digits: str) -> None:
         if self.state != SipState.IN_CALL:

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -167,6 +167,7 @@ class SipClient:
         self._invite_auth_tried = False
         self._incoming_invite: sm.SipMessage | None = None
         self._dialog_routes: list[str] = []
+        self._accepted_dialog_to = ""
 
         # negotiated media
         self._remote_rtp_ip = ""
@@ -498,6 +499,7 @@ class SipClient:
         self._outbound = True
         self._invite_auth_tried = False
         self._dialog_routes = []
+        self._accepted_dialog_to = ""
         self._d_call_id = sm.gen_call_id(self._local_ip)
         self._d_local_tag = sm.gen_tag()
         self._d_branch = sm.gen_branch()
@@ -600,7 +602,9 @@ class SipClient:
         )
         return msg
 
-    def _build_ack(self, resp: sm.SipMessage) -> str:
+    def _build_ack(
+        self, resp: sm.SipMessage, routes: list[str] | None = None
+    ) -> str:
         to = resp.header("To")
         target = _angle_uri(resp.header("Contact")) or self._d_remote_target
         try:
@@ -625,7 +629,7 @@ class SipClient:
         if self._service_routes and 300 <= resp.status_code < 700:
             msg += f"Route: {self._service_routes}\r\n"
         elif 200 <= resp.status_code < 300:
-            msg += self._dialog_route_header()
+            msg += self._dialog_route_header(routes)
 
         msg += (
             f"From: {self._d_local}\r\n"
@@ -640,10 +644,18 @@ class SipClient:
         if not self._outbound:
             return
 
+        cseq_parts = m.header("CSeq").split()
         try:
-            cseq_num = int(m.header("CSeq").split()[0])
+            cseq_num = int(cseq_parts[0])
         except (ValueError, IndexError):
             cseq_num = 0
+
+        if (
+            len(cseq_parts) < 2
+            or cseq_parts[1].upper() != "INVITE"
+            or m.header("Call-ID") != self._d_call_id
+        ):
+            return
 
         if cseq_num != self._d_cseq:
             # Ignore responses for old transactions, but re-ACK final failures (>=300)
@@ -689,22 +701,34 @@ class SipClient:
             return
 
         if 200 <= m.status_code < 300:
-            # Retransmitted 2xx (our ACK was lost): re-ACK only, no duplicate setup.
-            if self.state == SipState.IN_CALL:
-                self._send_raw(self._build_ack(m))
+            response_routes = list(
+                reversed(sm.split_header_values(m.header("Record-Route")))
+            )
+            response_to = m.header("To") or self._d_remote
+
+            # Every 2xx requires an ACK. A retransmission of the accepted
+            # dialog must not repeat media setup, even if the call has ended.
+            if self._accepted_dialog_to:
+                if response_to == self._accepted_dialog_to:
+                    self._send_raw(self._build_ack(m, response_routes))
+                else:
+                    self._end_forked_dialog(m, response_routes, response_to)
+                return
+
+            # A 2xx can race with local cancellation. Acknowledge and close
+            # the unwanted dialog without reviving the call.
+            if self.state not in (SipState.INVITING, SipState.RINGING_OUT):
+                self._end_forked_dialog(m, response_routes, response_to)
                 return
             if self._ring_timeout_handle is not None:
                 self._ring_timeout_handle.cancel()
                 self._ring_timeout_handle = None
-            to = m.header("To")
-            if to:
-                self._d_remote = to
+            self._accepted_dialog_to = response_to
+            self._d_remote = response_to
             contact_uri = _angle_uri(m.header("Contact"))
             if contact_uri:
                 self._d_remote_target = contact_uri
-            self._dialog_routes = list(
-                reversed(sm.split_header_values(m.header("Record-Route")))
-            )
+            self._dialog_routes = response_routes
             self._apply_remote_sdp(sm.parse_sdp(m.body))
             self._send_raw(self._build_ack(m))
 
@@ -783,6 +807,8 @@ class SipClient:
             f"CSeq: {req.header('CSeq')}\r\n"
         )
         if 200 <= code < 300 and req.method == "INVITE":
+            if record_route := req.header("Record-Route"):
+                msg += f"Record-Route: {record_route}\r\n"
             msg += f"Contact: {self._contact_uri()}\r\n"
         msg += f"User-Agent: {USER_AGENT}\r\n"
         if with_sdp:
@@ -954,24 +980,49 @@ class SipClient:
             self._send_raw(self._build_response(self._incoming_invite, code, reason, False))
             self._end_call()
 
-    def _build_in_dialog(self, method: str) -> str:
+    def _build_in_dialog(
+        self,
+        method: str,
+        *,
+        target: str | None = None,
+        remote: str | None = None,
+        routes: list[str] | None = None,
+        cseq: int | None = None,
+    ) -> str:
         return (
-            f"{method} {self._d_remote_target} SIP/2.0\r\n"
+            f"{method} {target or self._d_remote_target} SIP/2.0\r\n"
             f"Via: SIP/2.0/UDP {self._local_ip}:{self._local_port};branch={sm.gen_branch()};rport\r\n"
             "Max-Forwards: 70\r\n"
-            f"{self._dialog_route_header()}"
+            f"{self._dialog_route_header(routes)}"
             f"From: {self._d_local}\r\n"
-            f"To: {self._d_remote}\r\n"
+            f"To: {remote or self._d_remote}\r\n"
             f"Call-ID: {self._d_call_id}\r\n"
-            f"CSeq: {self._d_cseq} {method}\r\n"
+            f"CSeq: {cseq if cseq is not None else self._d_cseq} {method}\r\n"
             f"User-Agent: {USER_AGENT}\r\n"
             "Content-Length: 0\r\n\r\n"
         )
 
-    def _dialog_route_header(self) -> str:
-        if not self._dialog_routes:
+    def _dialog_route_header(self, routes: list[str] | None = None) -> str:
+        active_routes = self._dialog_routes if routes is None else routes
+        if not active_routes:
             return ""
-        return f"Route: {', '.join(self._dialog_routes)}\r\n"
+        return f"Route: {', '.join(active_routes)}\r\n"
+
+    def _end_forked_dialog(
+        self, response: sm.SipMessage, routes: list[str], remote: str
+    ) -> None:
+        """Acknowledge and close an unwanted 2xx dialog without changing state."""
+        target = _angle_uri(response.header("Contact")) or self._d_remote_target
+        self._send_raw(self._build_ack(response, routes))
+        self._send_raw(
+            self._build_in_dialog(
+                "BYE",
+                target=target,
+                remote=remote,
+                routes=routes,
+                cseq=self._d_cseq + 1,
+            )
+        )
 
     def send_dtmf(self, digits: str) -> None:
         if self.state != SipState.IN_CALL:

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -163,6 +163,7 @@ class SipClient:
         self._d_local_tag = ""
         self._d_branch = ""
         self._d_cseq = 0
+        self._invite_cseq = 0
         self._outbound = False
         self._invite_auth_tried = False
         self._incoming_invite: sm.SipMessage | None = None
@@ -504,6 +505,7 @@ class SipClient:
         self._d_local_tag = sm.gen_tag()
         self._d_branch = sm.gen_branch()
         self._d_cseq = 1
+        self._invite_cseq = self._d_cseq
         self._invite_number = number
         disp = self.config.caller_id or self.config.username
         self._d_local = (
@@ -610,7 +612,7 @@ class SipClient:
         try:
             cseq = resp.header("CSeq").split()[0]
         except (ValueError, IndexError):
-            cseq = str(self._d_cseq)
+            cseq = str(self._invite_cseq)
             
         if 300 <= resp.status_code < 700:
             # ACK to a non-2xx response MUST use the exact same branch as the original request
@@ -657,7 +659,7 @@ class SipClient:
         ):
             return
 
-        if cseq_num != self._d_cseq:
+        if cseq_num != self._invite_cseq:
             # Ignore responses for old transactions, but re-ACK final failures (>=300)
             # to stop server retransmissions.
             if 300 <= m.status_code < 700:
@@ -685,6 +687,7 @@ class SipClient:
                 nonce, "auth" if qop else "", nc, cnonce,
             )
             self._d_cseq += 1
+            self._invite_cseq = self._d_cseq
             self._d_branch = sm.gen_branch()
             msg = self._build_invite()
             auth = self._digest_auth_line(
@@ -953,7 +956,6 @@ class SipClient:
             self._send_raw(self._build_in_dialog("BYE"))
             self._end_call()
         elif self.state in (SipState.INVITING, SipState.RINGING_OUT):
-            self._d_cseq += 1
             msg = (
                 f"CANCEL {self._d_remote_target} SIP/2.0\r\n"
                 f"Via: SIP/2.0/UDP {self._local_ip}:{self._local_port};branch={self._d_branch};rport\r\n"
@@ -961,7 +963,7 @@ class SipClient:
                 f"From: {self._d_local}\r\n"
                 f"To: {self._d_remote}\r\n"
                 f"Call-ID: {self._d_call_id}\r\n"
-                f"CSeq: {self._d_cseq} CANCEL\r\n"
+                f"CSeq: {self._invite_cseq} CANCEL\r\n"
                 "Content-Length: 0\r\n\r\n"
             )
             self._send_raw(msg)

--- a/custom_components/sip/sip_client/sip_message.py
+++ b/custom_components/sip/sip_client/sip_message.py
@@ -58,6 +58,35 @@ _COMPACT_HEADERS = {
     "v": "via",
 }
 
+_COMMA_LIST_HEADERS = {"record-route", "route", "service-route", "via"}
+
+
+def split_header_values(value: str) -> list[str]:
+    """Split a comma-list SIP header without splitting nested commas."""
+    values: list[str] = []
+    start = 0
+    angle_depth = 0
+    quoted = False
+    escaped = False
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+        elif quoted and char == "\\":
+            escaped = True
+        elif char == '"':
+            quoted = not quoted
+        elif not quoted and char == "<":
+            angle_depth += 1
+        elif not quoted and char == ">" and angle_depth:
+            angle_depth -= 1
+        elif not quoted and angle_depth == 0 and char == ",":
+            if item := value[start:index].strip():
+                values.append(item)
+            start = index + 1
+    if item := value[start:].strip():
+        values.append(item)
+    return values
+
 
 def parse_sip_message(raw: str) -> SipMessage:
     msg = SipMessage()
@@ -103,10 +132,11 @@ def parse_sip_message(raw: str) -> SipMessage:
         name = _COMPACT_HEADERS.get(name, name)
         value = line[colon + 1:].strip()
         last_name = name
-        # Keep the first occurrence (topmost Via, etc.), except for Service-Route.
+        # List-valued routing headers can be represented as repeated rows or one
+        # comma-separated row. Preserve their wire order in a combined value.
         if name not in msg.headers:
             msg.headers[name] = value
-        elif name == "service-route":
+        elif name in _COMMA_LIST_HEADERS:
             msg.headers[name] += f", {value}"
     return msg
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -424,7 +424,8 @@ def test_successful_invite_ack_and_bye_use_reversed_record_route():
         client.state = sip_client.SipState.RINGING_OUT
         response = sm.parse_sip_message(
             "SIP/2.0 200 OK\r\n"
-            "Record-Route: <sip:first.example;lr>,<sip:second.example;lr>\r\n"
+            "Record-Route: <sip:first.example;lr>,<sip:middle.example;lr>\r\n"
+            "Record-Route: <sip:last.example;lr>\r\n"
             "To: <sip:bob@example>;tag=remote\r\n"
             "Contact: <sip:bob@target.example>\r\n"
             "Call-ID: call@example\r\n"
@@ -434,23 +435,112 @@ def test_successful_invite_ack_and_bye_use_reversed_record_route():
         with (
             patch.object(client, "_send_raw") as send,
             patch.object(client, "_apply_remote_sdp"),
-            patch.object(client, "_start_media", AsyncMock()),
+            patch.object(client, "_start_media", AsyncMock()) as start_media,
         ):
             client._handle_invite_response(response)
             first_ack = send.call_args_list[0].args[0]
             client._handle_invite_response(response)
             repeated_ack = send.call_args_list[1].args[0]
+            client.state = sip_client.SipState.REGISTERED
+            client._handle_invite_response(response)
+            delayed_ack = send.call_args_list[2].args[0]
             await asyncio.sleep(0)
         client._d_cseq += 1
-        return first_ack, repeated_ack, client._build_in_dialog("BYE")
+        return (
+            first_ack,
+            repeated_ack,
+            delayed_ack,
+            client._build_in_dialog("BYE"),
+            start_media.await_count,
+            client.state,
+        )
 
-    first_ack, repeated_ack, bye = asyncio.run(run())
-    expected = "Route: <sip:second.example;lr>, <sip:first.example;lr>\r\n"
+    first_ack, repeated_ack, delayed_ack, bye, media_starts, state = asyncio.run(run())
+    expected = (
+        "Route: <sip:last.example;lr>, <sip:middle.example;lr>, "
+        "<sip:first.example;lr>\r\n"
+    )
     assert expected in first_ack
     assert expected in repeated_ack
+    assert expected in delayed_ack
     assert expected in bye
     assert first_ack.startswith("ACK sip:bob@target.example SIP/2.0\r\n")
     assert bye.startswith("BYE sip:bob@target.example SIP/2.0\r\n")
+    assert media_starts == 1
+    assert state == sip_client.SipState.REGISTERED
+
+
+def test_invite_response_from_previous_call_id_is_ignored():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._outbound = True
+        client._d_call_id = "current@example"
+        client._d_cseq = 1
+        client.state = sip_client.SipState.RINGING_OUT
+        response = sm.parse_sip_message(
+            "SIP/2.0 200 OK\r\n"
+            "To: <sip:bob@example>;tag=old\r\n"
+            "Contact: <sip:bob@old.example>\r\n"
+            "Call-ID: previous@example\r\n"
+            "CSeq: 1 INVITE\r\n"
+            "Content-Length: 0\r\n\r\n"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client, "_start_media", AsyncMock()) as start_media,
+        ):
+            client._handle_invite_response(response)
+        return client, send, start_media
+
+    client, send, start_media = asyncio.run(run())
+    send.assert_not_called()
+    start_media.assert_not_awaited()
+    assert client.state == sip_client.SipState.RINGING_OUT
+
+
+def test_forked_invite_2xx_is_acknowledged_and_ended_without_replacing_dialog():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._local_ip = "192.0.2.10"
+        client._local_port = 5060
+        client._outbound = True
+        client._d_call_id = "call@example"
+        client._d_local = "<sip:alice@example>;tag=local"
+        client._d_remote = "<sip:bob@example>;tag=accepted"
+        client._d_remote_target = "sip:bob@accepted.example"
+        client._d_cseq = 1
+        client._dialog_routes = ["<sip:accepted-proxy.example;lr>"]
+        client._accepted_dialog_to = client._d_remote
+        client.state = sip_client.SipState.IN_CALL
+        response = sm.parse_sip_message(
+            "SIP/2.0 200 OK\r\n"
+            "Record-Route: <sip:first-fork.example;lr>,<sip:last-fork.example;lr>\r\n"
+            "To: <sip:bob@example>;tag=forked\r\n"
+            "Contact: <sip:bob@forked.example>\r\n"
+            "Call-ID: call@example\r\n"
+            "CSeq: 1 INVITE\r\n"
+            "Content-Length: 0\r\n\r\n"
+        )
+        with patch.object(client, "_send_raw") as send:
+            client._handle_invite_response(response)
+        return client, [call.args[0] for call in send.call_args_list]
+
+    client, sent = asyncio.run(run())
+    assert len(sent) == 2
+    assert sent[0].startswith("ACK sip:bob@forked.example SIP/2.0\r\n")
+    assert sent[1].startswith("BYE sip:bob@forked.example SIP/2.0\r\n")
+    expected = "Route: <sip:last-fork.example;lr>, <sip:first-fork.example;lr>\r\n"
+    assert expected in sent[0]
+    assert expected in sent[1]
+    assert client._d_remote == "<sip:bob@example>;tag=accepted"
+    assert client._d_remote_target == "sip:bob@accepted.example"
+    assert client._dialog_routes == ["<sip:accepted-proxy.example;lr>"]
 
 
 def test_new_outbound_call_clears_previous_dialog_routes():
@@ -490,12 +580,14 @@ def test_inbound_dialog_keeps_record_route_wire_order():
             "v=0\r\nc=IN IP4 198.51.100.10\r\n"
             "m=audio 4000 RTP/AVP 8\r\na=rtpmap:8 PCMA/8000\r\n"
         )
-        with patch.object(client, "_send_raw"):
+        with patch.object(client, "_send_raw") as send:
             client._handle_request(invite)
-        return client._build_in_dialog("BYE")
+            response = client._build_response(invite, 200, "OK", True)
+        return client._build_in_dialog("BYE"), response, send
 
-    bye = asyncio.run(run())
+    bye, response, _send = asyncio.run(run())
     assert "Route: <sip:first.example;lr>, <sip:second.example;lr>\r\n" in bye
+    assert "Record-Route: <sip:first.example;lr>,<sip:second.example;lr>\r\n" in response
 
 
 # ------------------------------------------------------- RFC 2833 RX

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -421,6 +421,8 @@ def test_successful_invite_ack_and_bye_use_reversed_record_route():
         client._d_remote = "<sip:bob@example>"
         client._d_remote_target = "sip:bob@example"
         client._d_cseq = 2
+        client._invite_cseq = 2
+        client.registered = True
         client.state = sip_client.SipState.RINGING_OUT
         response = sm.parse_sip_message(
             "SIP/2.0 200 OK\r\n"
@@ -441,21 +443,32 @@ def test_successful_invite_ack_and_bye_use_reversed_record_route():
             first_ack = send.call_args_list[0].args[0]
             client._handle_invite_response(response)
             repeated_ack = send.call_args_list[1].args[0]
-            client.state = sip_client.SipState.REGISTERED
+            client.hangup()
+            local_bye = send.call_args_list[2].args[0]
             client._handle_invite_response(response)
-            delayed_ack = send.call_args_list[2].args[0]
+            delayed_ack = send.call_args_list[3].args[0]
             await asyncio.sleep(0)
-        client._d_cseq += 1
         return (
             first_ack,
             repeated_ack,
             delayed_ack,
-            client._build_in_dialog("BYE"),
+            local_bye,
             start_media.await_count,
             client.state,
+            client._d_cseq,
+            client._invite_cseq,
         )
 
-    first_ack, repeated_ack, delayed_ack, bye, media_starts, state = asyncio.run(run())
+    (
+        first_ack,
+        repeated_ack,
+        delayed_ack,
+        bye,
+        media_starts,
+        state,
+        dialog_cseq,
+        invite_cseq,
+    ) = asyncio.run(run())
     expected = (
         "Route: <sip:last.example;lr>, <sip:middle.example;lr>, "
         "<sip:first.example;lr>\r\n"
@@ -468,6 +481,57 @@ def test_successful_invite_ack_and_bye_use_reversed_record_route():
     assert bye.startswith("BYE sip:bob@target.example SIP/2.0\r\n")
     assert media_starts == 1
     assert state == sip_client.SipState.REGISTERED
+    assert dialog_cseq == 3
+    assert invite_cseq == 2
+
+
+def test_cancel_race_acks_and_ends_late_2xx_with_original_invite_cseq():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._local_ip = "192.0.2.10"
+        client._local_port = 5060
+        client._outbound = True
+        client._d_call_id = "call@example"
+        client._d_local = "<sip:alice@example>;tag=local"
+        client._d_remote = "<sip:bob@example>"
+        client._d_remote_target = "sip:bob@example"
+        client._d_branch = "z9hG4bKinvite"
+        client._d_cseq = 2
+        client._invite_cseq = 2
+        client.registered = True
+        client.state = sip_client.SipState.RINGING_OUT
+        response = sm.parse_sip_message(
+            "SIP/2.0 200 OK\r\n"
+            "Record-Route: <sip:first.example;lr>,<sip:last.example;lr>\r\n"
+            "To: <sip:bob@example>;tag=late\r\n"
+            "Contact: <sip:bob@late.example>\r\n"
+            "Call-ID: call@example\r\n"
+            "CSeq: 2 INVITE\r\n"
+            "Content-Length: 0\r\n\r\n"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client, "_start_media", AsyncMock()) as start_media,
+        ):
+            client.hangup()
+            client._handle_invite_response(response)
+            await asyncio.sleep(0)
+        return client, [call.args[0] for call in send.call_args_list], start_media
+
+    client, sent, start_media = asyncio.run(run())
+    assert len(sent) == 3
+    assert sent[0].startswith("CANCEL sip:bob@example SIP/2.0\r\n")
+    assert "branch=z9hG4bKinvite;rport" in sent[0]
+    assert "CSeq: 2 CANCEL\r\n" in sent[0]
+    assert sent[1].startswith("ACK sip:bob@late.example SIP/2.0\r\n")
+    assert sent[2].startswith("BYE sip:bob@late.example SIP/2.0\r\n")
+    assert client._d_cseq == 2
+    assert client._invite_cseq == 2
+    assert client.state == sip_client.SipState.REGISTERED
+    start_media.assert_not_awaited()
 
 
 def test_invite_response_from_previous_call_id_is_ignored():
@@ -479,6 +543,7 @@ def test_invite_response_from_previous_call_id_is_ignored():
         client._outbound = True
         client._d_call_id = "current@example"
         client._d_cseq = 1
+        client._invite_cseq = 1
         client.state = sip_client.SipState.RINGING_OUT
         response = sm.parse_sip_message(
             "SIP/2.0 200 OK\r\n"
@@ -515,6 +580,7 @@ def test_forked_invite_2xx_is_acknowledged_and_ended_without_replacing_dialog():
         client._d_remote = "<sip:bob@example>;tag=accepted"
         client._d_remote_target = "sip:bob@accepted.example"
         client._d_cseq = 1
+        client._invite_cseq = 1
         client._dialog_routes = ["<sip:accepted-proxy.example;lr>"]
         client._accepted_dialog_to = client._d_remote
         client.state = sip_client.SipState.IN_CALL
@@ -556,9 +622,55 @@ def test_new_outbound_call_clears_previous_dialog_routes():
             patch.object(client, "_start_invite_retx"),
         ):
             client.call("1234")
-        return client._dialog_routes
+        return client._dialog_routes, client._d_cseq, client._invite_cseq
 
-    assert asyncio.run(run()) == []
+    assert asyncio.run(run()) == ([], 1, 1)
+
+
+def test_authenticated_invite_updates_retained_invite_cseq():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(
+            sip_client.SipConfig(
+                server="pbx.example",
+                username="alice",
+                password="secret",
+                domain="example",
+            )
+        )
+        client._local_ip = "192.0.2.10"
+        client._local_port = 5060
+        client._outbound = True
+        client._d_call_id = "call@example"
+        client._d_local = "<sip:alice@example>;tag=local"
+        client._d_remote = "<sip:bob@example>"
+        client._d_remote_target = "sip:bob@example"
+        client._d_branch = "z9hG4bKinitial"
+        client._d_cseq = 1
+        client._invite_cseq = 1
+        client.state = sip_client.SipState.INVITING
+        response = sm.parse_sip_message(
+            "SIP/2.0 407 Proxy Authentication Required\r\n"
+            "To: <sip:bob@example>;tag=proxy\r\n"
+            "Call-ID: call@example\r\n"
+            "CSeq: 1 INVITE\r\n"
+            'Proxy-Authenticate: Digest realm="example", nonce="abc123"\r\n'
+            "Content-Length: 0\r\n\r\n"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client, "_start_invite_retx"),
+        ):
+            client._handle_invite_response(response)
+        return client, [call.args[0] for call in send.call_args_list]
+
+    client, sent = asyncio.run(run())
+    assert client._d_cseq == 2
+    assert client._invite_cseq == 2
+    assert "CSeq: 1 ACK\r\n" in sent[0]
+    assert "CSeq: 2 INVITE\r\n" in sent[1]
 
 
 def test_inbound_dialog_keeps_record_route_wire_order():

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -189,6 +189,33 @@ def test_parse_request():
     assert m.header("call-id") == "xyz@host"
 
 
+def test_parse_combines_repeated_routing_headers_in_wire_order():
+    msg = sm.parse_sip_message(
+        "BYE sip:client@example SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP first.example;branch=1\r\n"
+        "Via: SIP/2.0/UDP second.example;branch=2\r\n"
+        "Record-Route: <sip:first.example;lr>\r\n"
+        "Record-Route: <sip:second.example;lr>\r\n\r\n"
+    )
+    assert msg.header("Via") == (
+        "SIP/2.0/UDP first.example;branch=1, "
+        "SIP/2.0/UDP second.example;branch=2"
+    )
+    assert msg.header("Record-Route") == (
+        "<sip:first.example;lr>, <sip:second.example;lr>"
+    )
+
+
+def test_split_header_values_ignores_nested_commas():
+    assert sm.split_header_values(
+        '"Proxy, One" <sip:first.example;lr>, '
+        '<sip:second.example?Subject=hello,world;lr>'
+    ) == [
+        '"Proxy, One" <sip:first.example;lr>',
+        '<sip:second.example?Subject=hello,world;lr>',
+    ]
+
+
 def test_parse_sdp():
     body = (
         "v=0\r\n"
@@ -356,6 +383,28 @@ def test_info_dtmf_ignores_other_content():
     assert p("application/dtmf-relay", "Duration=160") is None
 
 
+def test_response_copies_complete_via_chain():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        request = sm.parse_sip_message(
+            "BYE sip:alice@example SIP/2.0\r\n"
+            "Via: SIP/2.0/UDP first.example;branch=1\r\n"
+            "Via: SIP/2.0/UDP second.example;branch=2\r\n"
+            "From: <sip:bob@example>;tag=remote\r\n"
+            "To: <sip:alice@example>;tag=local\r\n"
+            "Call-ID: call@example\r\n"
+            "CSeq: 1 BYE\r\n\r\n"
+        )
+        return client._build_response(request, 200, "OK", False)
+
+    response = asyncio.run(run())
+    assert (
+        "Via: SIP/2.0/UDP first.example;branch=1, "
+        "SIP/2.0/UDP second.example;branch=2\r\n"
+    ) in response
 # ------------------------------------------------------- RFC 2833 RX
 def _te_packet(pt, marker, timestamp, event, seq=1):
     """Build one telephone-event RTP packet."""

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -53,7 +53,7 @@ except AttributeError:  # enum.StrEnum needs Python 3.11+ (CI runs 3.12+)
 # calls (FlowResult, cv.*). Stub those directly with setdefault so this works
 # standalone too — not just under pytest, where conftest.py already mocks
 # `homeassistant`/`homeassistant.core`/`homeassistant.config_entries`.
-from unittest.mock import MagicMock, patch  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
 import voluptuous as vol  # noqa: E402
 
 for _mod_name in (
@@ -405,6 +405,99 @@ def test_response_copies_complete_via_chain():
         "Via: SIP/2.0/UDP first.example;branch=1, "
         "SIP/2.0/UDP second.example;branch=2\r\n"
     ) in response
+
+
+def test_successful_invite_ack_and_bye_use_reversed_record_route():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._local_ip = "192.0.2.10"
+        client._local_port = 5060
+        client._outbound = True
+        client._d_call_id = "call@example"
+        client._d_local = "<sip:alice@example>;tag=local"
+        client._d_remote = "<sip:bob@example>"
+        client._d_remote_target = "sip:bob@example"
+        client._d_cseq = 2
+        client.state = sip_client.SipState.RINGING_OUT
+        response = sm.parse_sip_message(
+            "SIP/2.0 200 OK\r\n"
+            "Record-Route: <sip:first.example;lr>,<sip:second.example;lr>\r\n"
+            "To: <sip:bob@example>;tag=remote\r\n"
+            "Contact: <sip:bob@target.example>\r\n"
+            "Call-ID: call@example\r\n"
+            "CSeq: 2 INVITE\r\n"
+            "Content-Length: 0\r\n\r\n"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client, "_apply_remote_sdp"),
+            patch.object(client, "_start_media", AsyncMock()),
+        ):
+            client._handle_invite_response(response)
+            first_ack = send.call_args_list[0].args[0]
+            client._handle_invite_response(response)
+            repeated_ack = send.call_args_list[1].args[0]
+            await asyncio.sleep(0)
+        client._d_cseq += 1
+        return first_ack, repeated_ack, client._build_in_dialog("BYE")
+
+    first_ack, repeated_ack, bye = asyncio.run(run())
+    expected = "Route: <sip:second.example;lr>, <sip:first.example;lr>\r\n"
+    assert expected in first_ack
+    assert expected in repeated_ack
+    assert expected in bye
+    assert first_ack.startswith("ACK sip:bob@target.example SIP/2.0\r\n")
+    assert bye.startswith("BYE sip:bob@target.example SIP/2.0\r\n")
+
+
+def test_new_outbound_call_clears_previous_dialog_routes():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.state = sip_client.SipState.REGISTERED
+        client._dialog_routes = ["<sip:stale.example;lr>"]
+        with (
+            patch.object(client, "_send_raw"),
+            patch.object(client, "_start_invite_retx"),
+        ):
+            client.call("1234")
+        return client._dialog_routes
+
+    assert asyncio.run(run()) == []
+
+
+def test_inbound_dialog_keeps_record_route_wire_order():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.state = sip_client.SipState.REGISTERED
+        invite = sm.parse_sip_message(
+            "INVITE sip:alice@example SIP/2.0\r\n"
+            "Record-Route: <sip:first.example;lr>,<sip:second.example;lr>\r\n"
+            "From: <sip:bob@example>;tag=remote\r\n"
+            "To: <sip:alice@example>\r\n"
+            "Contact: <sip:bob@target.example>\r\n"
+            "Call-ID: inbound@example\r\n"
+            "CSeq: 1 INVITE\r\n"
+            "Content-Type: application/sdp\r\n\r\n"
+            "v=0\r\nc=IN IP4 198.51.100.10\r\n"
+            "m=audio 4000 RTP/AVP 8\r\na=rtpmap:8 PCMA/8000\r\n"
+        )
+        with patch.object(client, "_send_raw"):
+            client._handle_request(invite)
+        return client._build_in_dialog("BYE")
+
+    bye = asyncio.run(run())
+    assert "Route: <sip:first.example;lr>, <sip:second.example;lr>\r\n" in bye
+
+
 # ------------------------------------------------------- RFC 2833 RX
 def _te_packet(pt, marker, timestamp, event, seq=1):
     """Build one telephone-event RTP packet."""


### PR DESCRIPTION
## Why

Calls placed through a multi-hop SIP proxy could connect and exchange audio, then be ended by the remote side after roughly five seconds.

This initially looked like a Docker or NAT problem, but the diagnostic trace showed RTP packets and bytes flowing in both directions. The failure was in SIP signaling instead: the remote server retransmitted its `200 OK` several times because the ACK was not reaching it. That response supplied a `Record-Route` chain, but the client discarded the route set and sent the ACK directly. The parser also retained only one value from repeated `Via` headers, so responses to inbound requests could not reliably travel back through every proxy hop.

The fix implements the dialog-routing behavior defined by SIP rather than adding a provider-specific address or STUN option. It should therefore help any installation whose provider uses one or more signaling proxies, including installations that are not running in Docker.

## What changed

- Preserve ordered, repeated `Via`, `Route`, `Record-Route`, and `Service-Route` values, including comma-separated values.
- Build direction-appropriate dialog route sets from `Record-Route` and use them for ACK and BYE requests.
- Copy complete `Via` and `Record-Route` chains where SIP responses require them.
- Retain and validate INVITE transaction identity so CANCEL, delayed responses, retransmitted `2xx` responses, and forked responses do not corrupt the active call.

## Verification

- `uv run --with pytest --with voluptuous python -m pytest tests/` (93 passed)
- `uv run --with ruff python -m ruff check custom_components/`
- `uv run python -m compileall -q custom_components tests`
