### PR TITLE
fix: route in-dialog requests through strict routers

### DIFF
--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import enum
 import logging
+import re
 import socket
 import time
 from dataclasses import dataclass
@@ -115,6 +116,17 @@ def _angle_uri(value: str) -> str:
     # No angle brackets: treat the whole value as a bare URI (RFC 3261 §20.10)
     stripped = value.strip()
     return stripped if stripped.startswith("sip") else ""
+
+
+# A route is loose only when its URI carries an ";lr" parameter (RFC 3261
+# §19.1.1). Match it as a whole parameter so ";lrx" or a userinfo "lr" is not
+# mistaken for one.
+_LOOSE_ROUTE_PARAM = re.compile(r";lr(?=[;=?]|$)", re.IGNORECASE)
+
+
+def _is_loose_route(route: str) -> bool:
+    """Whether a Record-Route/Route field-value points at a loose router."""
+    return bool(_LOOSE_ROUTE_PARAM.search(_angle_uri(route) or route.strip()))
 
 
 class _SipProtocol(asyncio.DatagramProtocol):
@@ -622,18 +634,19 @@ class SipClient:
             branch = sm.gen_branch()
             
         via = f"SIP/2.0/UDP {self._local_ip}:{self._local_port};branch={branch};rport"
-            
+
+        if self._service_routes and 300 <= resp.status_code < 700:
+            route_block = f"Route: {self._service_routes}\r\n"
+        elif 200 <= resp.status_code < 300:
+            target, route_block = self._route_request(target, routes)
+        else:
+            route_block = ""
+
         msg = (
             f"ACK {target} SIP/2.0\r\n"
             f"Via: {via}\r\n"
             "Max-Forwards: 70\r\n"
-        )
-        if self._service_routes and 300 <= resp.status_code < 700:
-            msg += f"Route: {self._service_routes}\r\n"
-        elif 200 <= resp.status_code < 300:
-            msg += self._dialog_route_header(routes)
-
-        msg += (
+            f"{route_block}"
             f"From: {self._d_local}\r\n"
             f"To: {to or self._d_remote}\r\n"
             f"Call-ID: {self._d_call_id}\r\n"
@@ -809,7 +822,11 @@ class SipClient:
             f"Call-ID: {req.header('Call-ID')}\r\n"
             f"CSeq: {req.header('CSeq')}\r\n"
         )
-        if 200 <= code < 300 and req.method == "INVITE":
+        # RFC 3261 §12.1.1: every dialog-establishing response — the early
+        # dialog of a 18x included, not just the 2xx — must echo the request's
+        # Record-Route and carry a Contact the peer can route in-dialog
+        # requests to. Dropping either strands a proxy/SBC outside the dialog.
+        if req.method == "INVITE" and 101 <= code < 300:
             if record_route := req.header("Record-Route"):
                 msg += f"Record-Route: {record_route}\r\n"
             msg += f"Contact: {self._contact_uri()}\r\n"
@@ -991,11 +1008,14 @@ class SipClient:
         routes: list[str] | None = None,
         cseq: int | None = None,
     ) -> str:
+        request_uri, route_block = self._route_request(
+            target or self._d_remote_target, routes
+        )
         return (
-            f"{method} {target or self._d_remote_target} SIP/2.0\r\n"
+            f"{method} {request_uri} SIP/2.0\r\n"
             f"Via: SIP/2.0/UDP {self._local_ip}:{self._local_port};branch={sm.gen_branch()};rport\r\n"
             "Max-Forwards: 70\r\n"
-            f"{self._dialog_route_header(routes)}"
+            f"{route_block}"
             f"From: {self._d_local}\r\n"
             f"To: {remote or self._d_remote}\r\n"
             f"Call-ID: {self._d_call_id}\r\n"
@@ -1004,11 +1024,26 @@ class SipClient:
             "Content-Length: 0\r\n\r\n"
         )
 
-    def _dialog_route_header(self, routes: list[str] | None = None) -> str:
-        active_routes = self._dialog_routes if routes is None else routes
-        if not active_routes:
-            return ""
-        return f"Route: {', '.join(active_routes)}\r\n"
+    def _route_request(
+        self, target: str, routes: list[str] | None = None
+    ) -> tuple[str, str]:
+        """Resolve the Request-URI and Route block for an in-dialog request.
+
+        RFC 3261 §12.2.1.1: when the first hop is a loose router the remote
+        target stays in the Request-URI and the whole route set travels as
+        Route headers. A strict router instead takes the Request-URI, and the
+        remote target moves to the tail of the route set so it is not lost.
+        """
+        active = [r for r in (self._dialog_routes if routes is None else routes) if r.strip()]
+        if not active:
+            return target, ""
+        if _is_loose_route(active[0]):
+            return target, f"Route: {', '.join(active)}\r\n"
+        remaining = active[1:]
+        if target:
+            remaining = [*remaining, f"<{target}>"]
+        route_block = f"Route: {', '.join(remaining)}\r\n" if remaining else ""
+        return _angle_uri(active[0]) or active[0], route_block
 
     def _end_forked_dialog(
         self, response: sm.SipMessage, routes: list[str], remote: str

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -698,8 +698,101 @@ def test_inbound_dialog_keeps_record_route_wire_order():
         return client._build_in_dialog("BYE"), response, send
 
     bye, response, _send = asyncio.run(run())
+    assert bye.startswith("BYE sip:bob@target.example SIP/2.0\r\n")
     assert "Route: <sip:first.example;lr>, <sip:second.example;lr>\r\n" in bye
     assert "Record-Route: <sip:first.example;lr>,<sip:second.example;lr>\r\n" in response
+
+
+def _inbound_client_with_routes(record_route):
+    """Drive an incoming INVITE carrying `record_route` and return the client."""
+    client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+    client.state = sip_client.SipState.REGISTERED
+    invite = sm.parse_sip_message(
+        "INVITE sip:14@192.168.1.237:59436 SIP/2.0\r\n"
+        f"Record-Route: {record_route}\r\n"
+        "From: <sip:12@example>;tag=remote\r\n"
+        "To: <sip:14@example>\r\n"
+        "Contact: <sip:12@127.0.0.1:5060>\r\n"
+        "Call-ID: inbound@example\r\n"
+        "CSeq: 1 INVITE\r\n"
+        "Content-Type: application/sdp\r\n\r\n"
+        "v=0\r\nc=IN IP4 198.51.100.10\r\n"
+        "m=audio 4000 RTP/AVP 8\r\na=rtpmap:8 PCMA/8000\r\n"
+    )
+    with patch.object(client, "_send_raw"):
+        client._handle_request(invite)
+    return client, invite
+
+
+def test_strict_route_moves_first_hop_into_request_uri():
+    """A route set without ";lr" is a strict router (RFC 3261 §12.2.1.1).
+
+    The 3CX SBC in issue #39 record-routes without ";lr", so sending the BYE
+    to the peer's Contact would address 127.0.0.1 and never reach the SBC.
+    """
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _ = _inbound_client_with_routes(
+            "<sip:3CXSBC@192.168.1.194:5060;user=proxy;tnlid=sbc.c8d9>"
+        )
+        return client._build_in_dialog("BYE")
+
+    bye = asyncio.run(run())
+    assert bye.startswith(
+        "BYE sip:3CXSBC@192.168.1.194:5060;user=proxy;tnlid=sbc.c8d9 SIP/2.0\r\n"
+    )
+    # The unreachable Contact is preserved as the final route, not dropped.
+    assert "Route: <sip:12@127.0.0.1:5060>\r\n" in bye
+
+
+def test_strict_route_keeps_remaining_hops_from_combined_header():
+    """Comma-combined and repeated Record-Route rows must behave identically."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _ = _inbound_client_with_routes(
+            "<sip:sbc.example>,<sip:middle.example>"
+        )
+        return client._build_in_dialog("BYE")
+
+    bye = asyncio.run(run())
+    assert bye.startswith("BYE sip:sbc.example SIP/2.0\r\n")
+    assert "Route: <sip:middle.example>, <sip:12@127.0.0.1:5060>\r\n" in bye
+
+
+def test_lr_lookalike_param_is_not_treated_as_loose():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _ = _inbound_client_with_routes("<sip:sbc.example;lrx=1>")
+        return client._build_in_dialog("BYE")
+
+    bye = asyncio.run(run())
+    assert bye.startswith("BYE sip:sbc.example;lrx=1 SIP/2.0\r\n")
+
+
+def test_ringing_response_establishes_early_dialog():
+    """18x opens an early dialog, so it needs Record-Route and Contact too."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client, invite = _inbound_client_with_routes("<sip:sbc.example;lr>")
+        return (
+            client._build_response(invite, 180, "Ringing", False),
+            client._build_response(invite, 100, "Trying", False),
+        )
+
+    ringing, trying = asyncio.run(run())
+    assert "Record-Route: <sip:sbc.example;lr>\r\n" in ringing
+    assert "Contact: <sip:" in ringing
+    # 100 Trying is not dialog-establishing and must stay bare.
+    assert "Record-Route:" not in trying
+    assert "Contact:" not in trying
 
 
 # ------------------------------------------------------- RFC 2833 RX


### PR DESCRIPTION
Closes #39.

## Context

#38 (1.10.1) already fixed the reporter's headline symptom — the missing `Record-Route` on the `200 OK` that left the ACK stranded. They were debugging against **1.10.0**, so their write-up predates it. Re-checking their analysis against current `main`, five of their seven points are already in. This PR closes the two that are not.

## What changed

**Strict routing.** A route set whose first hop lacks `;lr` is a strict router, but `_dialog_route_header()` always applied the route set as if it were loose: the peer's Contact stayed in the Request-URI and every route travelled as a `Route` header. Behind the reporter's 3CX SBC that Contact is `127.0.0.1`, so the BYE addressed an unreachable target.

`_route_request()` now resolves the Request-URI alongside the Route block (RFC 3261 §12.2.1.1). `_build_ack()` and `_build_in_dialog()` share it, so **inbound and outbound** dialogs both benefit — the reporter's own patch only covered the inbound BYE.

`;lr` is matched as a whole URI parameter (`;lr(?=[;=?]|$)`), so `;lrx=1` is not misread as loose. A plain `";lr" in uri` check gets that wrong.

**Early dialogs.** `_build_response()` copied `Record-Route` and `Contact` only into 2xx. A 18x opens an early dialog and needs both, or the proxy is stranded outside it. The condition is now `101 <= code < 300`; `100 Trying` establishes no dialog and stays bare.

## What deliberately did not change

`sip_message.py` is untouched. The reporter proposed replacing the parser's combined-value storage with a `headers_all` list, but `main` already normalises **both** wire forms — repeated rows *and* one comma-separated row. Their version only handles repeated rows, which regresses the comma form:

```
Record-Route: <sip:p1.example;lr>, <sip:p2.example;lr>
  main → 2 values      their parser → 1 value
```

That drops a Via from responses (the very bug they set out to fix) and, on the strict path, silently discards every hop after the first. `split_header_values()` stays.

Adopting their files wholesale would also revert #38's `_invite_cseq` tracking, forked-2xx handling, CANCEL CSeq, and response Call-ID/method validation.

## Verification

Four new tests, each failing without the fix. Rendering the exact INVITE from #39 now produces:

```
BYE sip:3CXSBC@192.168.1.194:5060;user=proxy;tnlid=sbc.c8d96e60 SIP/2.0
Route: <sip:12@127.0.0.1:5060>
CSeq: 2 BYE
```

matching the flow the reporter confirmed 3CX answers with an immediate `200 OK`. The `200 OK` and `180` carry both Via values and the Record-Route.

`97 passed` on Python 3.12.

> [!NOTE]
> The suite needs Python 3.11+. Under 3.10 or older, `enum.StrEnum` makes the `sip_client` import fail and the `if sip_client is None: return` guards turn every SIP test into a silent pass — worth knowing before trusting a green run.

No version bump here, following the existing convention of bumping `manifest.json` in a separate commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)