### PR TITLE
fix: end hangup_on_end sessions after one silent turn, not the full budget

### DIFF
--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -433,6 +433,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             silence_seconds=silence_seconds,
             noise_suppression=noise_suppression,
             turn_tone=turn_tone,
+            hangup_on_end=hangup_on_end,
             stop_audio_fn=client.stop_audio,
             media_playing_fn=lambda: client.media_playing,
         )

--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -38,6 +38,10 @@ except ImportError:
 
 _SILENT_TURN_ERRORS = frozenset({"stt-no-text-recognized", "wake-word-timeout"})
 _MAX_CONSECUTIVE_ERRORS = 3
+# hangup_on_end callers want the call to end promptly once the caller has
+# stopped responding, rather than waiting through the full silent-turn
+# budget of a normal session.
+_HANGUP_ON_END_MAX_SILENT_TURNS = 1
 _ERROR_TURN_BACKOFF_SECONDS = 1.0
 _VAD_FRAME_BYTES = 320  # 10 ms @ 16 kHz s16le mono
 _VAD_SPEECH_THRESHOLD = 0.5
@@ -130,6 +134,7 @@ class AssistBridge(AudioSink):
         silence_seconds: float | None = None,
         noise_suppression: int = 0,
         turn_tone: bool = False,
+        hangup_on_end: bool = False,
         stop_audio_fn: Callable[..., None] | None = None,
         media_playing_fn: Callable[[], bool] | None = None,
     ) -> None:
@@ -144,6 +149,10 @@ class AssistBridge(AudioSink):
         self.sample_rate = sample_rate
         self.max_turns = max_turns
         self.max_silent_turns = max_silent_turns
+        if hangup_on_end:
+            self.max_silent_turns = min(
+                self.max_silent_turns, _HANGUP_ON_END_MAX_SILENT_TURNS
+            )
         self.barge_in = barge_in
         self.silence_seconds = silence_seconds
         self.noise_suppression = noise_suppression

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1307,6 +1307,62 @@ def test_assist_silent_turns_end_session():
     assert len(done_calls) == 1
 
 
+def test_assist_hangup_on_end_shrinks_silent_turn_budget():
+    """hangup_on_end ends after 1 silent turn instead of the configured 2.
+
+    Regression for #41: without a smaller budget, hangup_on_end callers wait
+    through the full silent-turn count before the call is torn down.
+    """
+    assist_mod, mock_ap, PET, PE = _assist_ctx()
+    turn_count = 0
+    done_calls = []
+
+    async def mock_pipeline(hass, **kwargs):
+        nonlocal turn_count
+        turn_count += 1
+        kwargs["event_callback"](PE(PET.ERROR, {"code": "stt-no-text-recognized"}))
+
+    mock_ap.async_pipeline_from_audio_stream.side_effect = mock_pipeline
+
+    bridge = assist_mod.AssistBridge(
+        MagicMock(),
+        play_source_fn=MagicMock(),
+        on_done_fn=lambda: done_calls.append(1),
+        max_silent_turns=2,
+        hangup_on_end=True,
+    )
+    _run_bridge_session(bridge)
+    assert turn_count == 1
+    assert len(done_calls) == 1
+
+
+def test_assist_hangup_on_end_does_not_widen_a_stricter_budget():
+    """hangup_on_end only ever shrinks the budget, never grows it.
+
+    An explicit max_silent_turns=0 already ends after the first silent turn;
+    hangup_on_end clamping it up to 1 would wait through an extra turn.
+    """
+    assist_mod, mock_ap, PET, PE = _assist_ctx()
+    turn_count = 0
+
+    async def mock_pipeline(hass, **kwargs):
+        nonlocal turn_count
+        turn_count += 1
+        kwargs["event_callback"](PE(PET.ERROR, {"code": "stt-no-text-recognized"}))
+
+    mock_ap.async_pipeline_from_audio_stream.side_effect = mock_pipeline
+
+    bridge = assist_mod.AssistBridge(
+        MagicMock(),
+        play_source_fn=MagicMock(),
+        on_done_fn=MagicMock(),
+        max_silent_turns=0,
+        hangup_on_end=True,
+    )
+    _run_bridge_session(bridge)
+    assert turn_count == 1
+
+
 def test_assist_conversation_id_carried_across_turns():
     assist_mod, mock_ap, PET, PE = _assist_ctx()
     conv_ids = []


### PR DESCRIPTION
Closes #41 (split out from #39 §17).

## Context

The reporter observed that with `hangup_on_end: true`, the closing TTS played but the call stayed up for roughly two more minutes before the BYE was sent.

My first pass at #41 assumed `continue_conversation` was a missing exit signal and proposed ending the session whenever it was `False`. That was wrong, and I've corrected the issue: `continue_conversation` reflects whether the assistant's last reply ended in a question mark (`homeassistant/components/conversation/chat_log.py`), not whether the conversation is over. A normal statement is `False` on nearly every turn, so acting on it directly would have hung up mid-conversation almost immediately — a worse bug than the one reported.

Re-reading `assist.py:393-406`, the existing streak logic is already correct: a successful non-continuing turn resets `silent_streak` to 0, and only a turn where STT genuinely detects no speech increments it. The ~2 minute wait is just `max_silent_turns` (default 2) multiplied by the STT engine's own no-speech timeout — the budget doing its job, sized for a normal session rather than one that wants to end quickly.

## Fix

`AssistBridge` now takes `hangup_on_end`, and when set, clamps `max_silent_turns` down to 1:

```python
if hangup_on_end:
    self.max_silent_turns = min(self.max_silent_turns, _HANGUP_ON_END_MAX_SILENT_TURNS)
```

`min(...)`, not an unconditional override — an explicitly stricter budget (e.g. `max_silent_turns=0`) is never widened. Sessions that don't set `hangup_on_end` are unaffected.

## Verification

Two new tests, both failing on `main` (the keyword argument doesn't exist yet):
- `hangup_on_end=True` with the default budget of 2 ends after 1 silent turn.
- `hangup_on_end=True` with an explicit `max_silent_turns=0` still ends after 1 turn, not 2 — guards against a future "always exactly 1" implementation that would widen an already-strict setting.

`99 passed` on Python 3.12 (the suite needs 3.11+; see the note on #40's description for why a 3.9 run is misleading here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)