### PR TITLE
fix: drop non-digit RFC 4733 events and ignore DTMF INFO outside a call

### DIFF
--- a/custom_components/sip/manifest.json
+++ b/custom_components/sip/manifest.json
@@ -18,5 +18,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/eigger/hass-sip/issues",
-  "version": "1.11.0"
+  "version": "1.11.1"
 }

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -34,6 +34,19 @@ _DTMF_TONE_SAMPLES = 8 * SAMPLES_PER_FRAME  # ~160 ms, in CLOCK ticks
 _DTMF_END_PACKETS = 3
 
 
+def _dtmf_event_to_char(event: int) -> str | None:
+    """RFC 4733 event code -> DTMF character, or None for codes we do not expose."""
+    if event <= 9:
+        return chr(ord("0") + event)
+    if event == 10:
+        return "*"
+    if event == 11:
+        return "#"
+    if event <= 15:
+        return chr(ord("A") + (event - 12))
+    return None
+
+
 def _dtmf_char_to_event(c: str) -> int:
     if "0" <= c <= "9":
         return ord(c) - ord("0")
@@ -334,18 +347,10 @@ class RtpSession:
             timestamp = int.from_bytes(data[4:8], "big")
             if marker or timestamp != self._rx_dtmf_timestamp:
                 self._rx_dtmf_timestamp = timestamp
-                if self.on_dtmf is not None:
-                    event = data[header_len]
-                    if event <= 9:
-                        c = chr(ord("0") + event)
-                    elif event == 10:
-                        c = "*"
-                    elif event == 11:
-                        c = "#"
-                    elif event <= 15:
-                        c = chr(ord("A") + (event - 12))
-                    else:
-                        c = "?"
+                # Events above 15 (hook flash and up) are not DTMF digits;
+                # passing them on would hand IVR menus a bogus keypress.
+                c = _dtmf_event_to_char(data[header_len])
+                if c is not None and self.on_dtmf is not None:
                     self.on_dtmf(c)
             return
 

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -949,9 +949,15 @@ class SipClient:
             # of RFC 2833 telephone-event packets.
             self._send_raw(self._build_response(m, 200, "OK", False))
             digit = _parse_info_dtmf(m.header("Content-Type"), m.body)
-            if digit is not None:
-                _LOGGER.debug("DTMF '%s' received via SIP INFO", digit)
-                self._on_rx_dtmf(digit)
+            if digit is None:
+                return
+            # A keypress only means something inside a call. ANSWERING counts:
+            # the INFO can arrive before the ACK that moves us to IN_CALL.
+            if self.state not in (SipState.IN_CALL, SipState.ANSWERING):
+                _LOGGER.debug("DTMF '%s' via SIP INFO ignored in state %s", digit, self.state)
+                return
+            _LOGGER.debug("DTMF '%s' received via SIP INFO", digit)
+            self._on_rx_dtmf(digit)
             return
 
         # OPTIONS / unknown in-dialog request: acknowledge.

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -383,6 +383,56 @@ def test_info_dtmf_ignores_other_content():
     assert p("application/dtmf-relay", "Duration=160") is None
 
 
+def _info_dtmf_request(digit="1"):
+    body = f"Signal={digit}\r\nDuration=160\r\n"
+    return sm.parse_sip_message(
+        "INFO sip:alice@example SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP pbx.example;branch=z9hG4bKinfo\r\n"
+        "From: <sip:bob@example>;tag=remote\r\n"
+        "To: <sip:alice@example>;tag=local\r\n"
+        "Call-ID: inbound@example\r\n"
+        "CSeq: 2 INFO\r\n"
+        "Content-Type: application/dtmf-relay\r\n"
+        f"Content-Length: {len(body)}\r\n\r\n" + body
+    )
+
+
+def _handle_info_dtmf(state):
+    """Feed one DTMF INFO to a client in `state`; return (digits, responses)."""
+    async def run():
+        got = []
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example"),
+            sip_client.SipCallbacks(on_dtmf=got.append),
+        )
+        client.state = state
+        with patch.object(client, "_send_raw") as send:
+            client._handle_request(_info_dtmf_request())
+        return got, [c.args[0] for c in send.call_args_list]
+
+    return asyncio.run(run())
+
+
+def test_info_dtmf_fires_during_call():
+    if sip_client is None:
+        return
+    # ANSWERING too: the INFO can arrive before the ACK that ends it.
+    for state in (sip_client.SipState.IN_CALL, sip_client.SipState.ANSWERING):
+        digits, sent = _handle_info_dtmf(state)
+        assert digits == ["1"]
+        assert sent and sent[0].startswith("SIP/2.0 200 OK")
+
+
+def test_info_dtmf_outside_call_is_answered_but_not_delivered():
+    if sip_client is None:
+        return
+    # An INFO out of any call still gets its 200 OK, but must not inject a
+    # keypress into IVR menus / automations.
+    digits, sent = _handle_info_dtmf(sip_client.SipState.REGISTERED)
+    assert digits == []
+    assert sent and sent[0].startswith("SIP/2.0 200 OK")
+
+
 def test_response_copies_complete_via_chain():
     if sip_client is None:
         return
@@ -827,6 +877,11 @@ def test_rfc2833_rx_deduplicates_by_timestamp():
     packets = [_te_packet(101, False, 1000, 1) for _ in range(3)]
     packets += [_te_packet(101, False, 2000, 2) for _ in range(3)]
     assert _collect_dtmf(packets) == ["1", "2"]
+
+
+def test_rfc2833_rx_ignores_non_digit_events():
+    # Event 16 is hook flash, not a keypress: it must not reach on_dtmf.
+    assert _collect_dtmf([_te_packet(101, True, 1000, 16)]) == []
 
 
 def test_rfc2833_rx_marker_forces_new_event():


### PR DESCRIPTION
Two small correctness fixes in the DTMF receive path, spotted while porting
this logic to the ESPHome `sip_client` component
([espcomponents#319](https://github.com/eigger/espcomponents/pull/319)).

## 1. Non-digit telephone-event codes reached `on_dtmf`

RFC 4733 event codes above 15 (hook flash and up) are not DTMF digits, but the
decoder mapped them to a literal `"?"` and delivered it as a keypress — an IVR
menu or an `on_dtmf` automation could act on a flash. They are now dropped.

## 2. DTMF SIP INFO fired outside a call

A DTMF INFO fired the trigger in any state. It is still answered with `200 OK`,
but the digit is only delivered while a call is up. `ANSWERING` counts, because
the INFO can arrive before the ACK that moves the dialog to `IN_CALL`.

## Tests

- `test_rfc2833_rx_ignores_non_digit_events`
- `test_info_dtmf_fires_during_call` (`IN_CALL` and `ANSWERING`)
- `test_info_dtmf_outside_call_is_answered_but_not_delivered`

Both new tests fail on `main` and pass here; full suite 103 passed, `ruff check`
clean. Version bumped to 1.11.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
