### PR TITLE
fix: answer in-dialog re-INVITE (P0-1)

### DIFF
--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -345,6 +345,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if assist_bridge is not None:
             assist_bridge.on_playback_done()
 
+    @callback
+    def on_codec_change(codec) -> None:
+        nonlocal assist_bridge
+        if assist_bridge is not None:
+            assist_bridge.sample_rate = codec.sample_rate
+        recorder = entry.runtime_data.get("recorder")
+        if recorder is not None:
+            LOGGER.warning(
+                "[%s] Codec changed to %s (%s Hz) while recording; "
+                "the WAV header keeps the rate from when recording started",
+                sip_config.username,
+                codec.name,
+                codec.sample_rate,
+            )
+
     callbacks = SipCallbacks(
         on_state_change=on_state_change,
         on_registered=on_registered,
@@ -353,6 +368,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         on_call_ended=on_call_ended,
         on_dtmf=on_dtmf,
         on_playback_done=on_playback_done,
+        on_codec_change=on_codec_change,
     )
 
     client = SipClient(sip_config, callbacks)

--- a/custom_components/sip/sip_client/codecs.py
+++ b/custom_components/sip/sip_client/codecs.py
@@ -141,15 +141,21 @@ def keep_or_choose(current: Codec, sdp: SdpInfo) -> Codec:
     A mid-dialog refresh that still advertises the negotiated codec must not
     switch (or rebuild encoder state). An offer with no audio payloads — an
     offerless re-INVITE or a session-timer refresh — also leaves ``current``.
+
+    Dynamic payload types (>= 96) are matched by codec name, not number:
+    the same PT can be PCMU in one offer and G.722 in the next.
     """
-    if current.payload_type in sdp.offered_pts:
-        return current
     named = {
         "G722": sdp.g722_pt,
         "PCMU": sdp.pcmu_pt,
         "PCMA": sdp.pcma_pt,
     }
     npt = named.get(current.name, -1)
+    if current.payload_type >= 96:
+        if npt >= 0:
+            return current.with_payload_type(npt)
+    elif current.payload_type in sdp.offered_pts:
+        return current
     if npt >= 0:
         return current.with_payload_type(npt)
     if not sdp.offered_pts and sdp.pcmu_pt < 0 and sdp.pcma_pt < 0 and sdp.g722_pt < 0:

--- a/custom_components/sip/sip_client/codecs.py
+++ b/custom_components/sip/sip_client/codecs.py
@@ -135,6 +135,28 @@ def choose(sdp: SdpInfo) -> Codec:
     return DEFAULT
 
 
+def keep_or_choose(current: Codec, sdp: SdpInfo) -> Codec:
+    """Keep ``current`` when the offer still lists it; otherwise :func:`choose`.
+
+    A mid-dialog refresh that still advertises the negotiated codec must not
+    switch (or rebuild encoder state). An offer with no audio payloads — an
+    offerless re-INVITE or a session-timer refresh — also leaves ``current``.
+    """
+    if current.payload_type in sdp.offered_pts:
+        return current
+    named = {
+        "G722": sdp.g722_pt,
+        "PCMU": sdp.pcmu_pt,
+        "PCMA": sdp.pcma_pt,
+    }
+    npt = named.get(current.name, -1)
+    if npt >= 0:
+        return current.with_payload_type(npt)
+    if not sdp.offered_pts and sdp.pcmu_pt < 0 and sdp.pcma_pt < 0 and sdp.g722_pt < 0:
+        return current
+    return choose(sdp)
+
+
 def sdp_media_line(port: int, only: Codec | None = None) -> str:
     """Build the ``m=audio`` line. Pass ``only`` to answer with one codec (RFC 3264)."""
     if only is not None:

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -146,6 +146,7 @@ class RtpSession:
         self._tx_paused_at = self._loop.time()
         self.tx_enabled = False
         self.flush_tx_buffer()
+        self._clear_dtmf_tx()
 
     def clear_tx_pause(self) -> None:
         """Re-enable TX without catching up a hold gap (new/ended call)."""
@@ -196,8 +197,7 @@ class RtpSession:
         self._ssrc = struct.unpack("<I", os.urandom(4))[0]
         self._first_packet = True
         self._tx_buffer.clear()
-        self._dtmf_queue.clear()
-        self._dtmf_active = False
+        self._clear_dtmf_tx()
         self._rx_dtmf_timestamp = -1
         # Fresh codec state for this call (important for stateful codecs).
         self.set_codec(self._codec)
@@ -227,8 +227,7 @@ class RtpSession:
             self._transport.close()
             self._transport = None
         self._tx_buffer.clear()
-        self._dtmf_queue.clear()
-        self._dtmf_active = False
+        self._clear_dtmf_tx()
         self._rx_dtmf_timestamp = -1
 
     # -- TX -------------------------------------------------------------
@@ -244,6 +243,14 @@ class RtpSession:
     def flush_tx_buffer(self) -> None:
         """Drop queued PCM not yet sent (e.g. after barge-in)."""
         self._tx_buffer.clear()
+
+    def _clear_dtmf_tx(self) -> None:
+        """Drop in-flight and queued DTMF so a later resume cannot rewind RTP time."""
+        self._dtmf_queue.clear()
+        self._dtmf_active = False
+        self._dtmf_event = -1
+        self._dtmf_duration = 0
+        self._dtmf_end_packets = 0
 
     def queue_dtmf(self, digits: str) -> None:
         if self.dtmf_pt < 0:

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -80,6 +80,7 @@ class RtpSession:
         self._remote: tuple[str, int] | None = None
         self.dtmf_pt = 101
         self.send_silence = True
+        self.tx_enabled = True
 
         self._seq = 0
         self._timestamp = 0
@@ -202,7 +203,7 @@ class RtpSession:
     # -- TX -------------------------------------------------------------
     def push_tx_audio(self, pcm_le: bytes) -> None:
         """Queue captured PCM (s16le, mono, codec sample rate) for transmission."""
-        if self._transport is None:
+        if self._transport is None or not self.tx_enabled:
             return
         self._tx_buffer.extend(pcm_le)
         if len(self._tx_buffer) > self._tx_buffer_max:
@@ -291,7 +292,7 @@ class RtpSession:
         while True:
             next_t += FRAME_SEC
             try:
-                if self._remote is not None:
+                if self._remote is not None and self.tx_enabled:
                     if self._dtmf_active or self._dtmf_queue:
                         self._send_dtmf_packet()
                     elif len(self._tx_buffer) >= self._pcm_frame_bytes:

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -81,6 +81,7 @@ class RtpSession:
         self.dtmf_pt = 101
         self.send_silence = True
         self.tx_enabled = True
+        self._tx_paused_at: float | None = None
 
         self._seq = 0
         self._timestamp = 0
@@ -120,6 +121,36 @@ class RtpSession:
     # -- configuration --------------------------------------------------
     def set_remote(self, ip: str, port: int) -> None:
         self._remote = (ip, port)
+
+    def set_tx_enabled(self, enabled: bool) -> None:
+        """Gate RTP transmission; on resume, catch up the RTP timestamp.
+
+        While TX is paused the sender loop does not advance ``_timestamp``.
+        Jumping it by the elapsed 20 ms frames (and re-marking the next
+        packet) keeps a long hold from looking like a burst of late packets.
+        """
+        if enabled == self.tx_enabled:
+            return
+        if enabled:
+            if self._tx_paused_at is not None:
+                elapsed = max(0.0, self._loop.time() - self._tx_paused_at)
+                frames = int(elapsed / FRAME_SEC)
+                if frames:
+                    self._timestamp = (
+                        self._timestamp + frames * self._ts_increment
+                    ) & 0xFFFFFFFF
+                self._first_packet = True
+            self._tx_paused_at = None
+            self.tx_enabled = True
+            return
+        self._tx_paused_at = self._loop.time()
+        self.tx_enabled = False
+        self.flush_tx_buffer()
+
+    def clear_tx_pause(self) -> None:
+        """Re-enable TX without catching up a hold gap (new/ended call)."""
+        self.tx_enabled = True
+        self._tx_paused_at = None
 
     def set_codec(self, codec: Codec) -> None:
         """Bind the negotiated codec and (re)create encoder/decoder state."""

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -129,6 +129,20 @@ def _is_loose_route(route: str) -> bool:
     return bool(_LOOSE_ROUTE_PARAM.search(_angle_uri(route) or route.strip()))
 
 
+def _cseq_number(header: str) -> int:
+    try:
+        return int(header.split()[0])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _via_branch(via: str) -> str:
+    """Branch of the top Via (the transaction this request belongs to)."""
+    first = via.split(",", 1)[0]
+    match = re.search(r";branch=([^;,\s]+)", first, re.IGNORECASE)
+    return match.group(1) if match else ""
+
+
 class _SipProtocol(asyncio.DatagramProtocol):
     def __init__(self, on_packet: Callable[[bytes], None]) -> None:
         self._on_packet = on_packet
@@ -181,6 +195,11 @@ class SipClient:
         self._incoming_invite: sm.SipMessage | None = None
         self._dialog_routes: list[str] = []
         self._accepted_dialog_to = ""
+        # Last INVITE we received in this dialog (initial or re-INVITE). Used
+        # to tell a retransmission (same CSeq + branch) from a re-INVITE.
+        self._remote_invite_cseq = 0
+        self._remote_invite_branch = ""
+        self._on_hold = False
 
         # negotiated media
         self._remote_rtp_ip = ""
@@ -513,6 +532,10 @@ class SipClient:
         self._invite_auth_tried = False
         self._dialog_routes = []
         self._accepted_dialog_to = ""
+        self._remote_invite_cseq = 0
+        self._remote_invite_branch = ""
+        self._on_hold = False
+        self.rtp.send_silence = True
         self._d_call_id = sm.gen_call_id(self._local_ip)
         self._d_local_tag = sm.gen_tag()
         self._d_branch = sm.gen_branch()
@@ -580,6 +603,8 @@ class SipClient:
         remote never offered (RFC 3264).
         """
         sid = str(int(time.time()))
+        # RFC 3264: answer sendonly with recvonly, inactive with inactive.
+        direction = "recvonly" if self._on_hold else "sendrecv"
         return (
             "v=0\r\n"
             f"o=- {sid} {sid} IN IP4 {self._local_ip}\r\n"
@@ -590,7 +615,7 @@ class SipClient:
             f"{codecs.sdp_rtpmaps(only=only)}"
             "a=fmtp:101 0-15\r\n"
             "a=ptime:20\r\n"
-            "a=sendrecv\r\n"
+            f"a={direction}\r\n"
         )
 
     def _build_invite(self) -> str:
@@ -778,9 +803,12 @@ class SipClient:
         return auth + "\r\n"
 
     def _apply_remote_sdp(self, sdp: sm.SdpInfo) -> None:
-        if sdp.connection_ip:
+        old_ip, old_port = self._remote_rtp_ip, self._remote_rtp_port
+        # RFC 2543 hold uses c=0.0.0.0; keep the last real destination.
+        if sdp.connection_ip and sdp.connection_ip not in ("0.0.0.0", "0:0:0:0:0:0:0:0", "::"):
             self._remote_rtp_ip = sdp.connection_ip
-        self._remote_rtp_port = sdp.audio_port
+        if sdp.audio_port:
+            self._remote_rtp_port = sdp.audio_port
         self._codec = codecs.choose(sdp)
         self._chosen_pt = self._codec.payload_type
         self._remote_dtmf_pt = sdp.telephone_event_pt
@@ -789,6 +817,26 @@ class SipClient:
         self.rtp.set_codec(self._codec)
         if self._remote_dtmf_pt >= 0:
             self.rtp.dtmf_pt = self._remote_dtmf_pt
+
+        self._set_hold(sdp.is_hold)
+        # Re-INVITE / UPDATE may move the remote RTP endpoint (direct media).
+        # Retarget the existing session; do not tear it down.
+        if (
+            self._media_active
+            and self._remote_rtp_ip
+            and self._remote_rtp_port
+            and (self._remote_rtp_ip, self._remote_rtp_port) != (old_ip, old_port)
+        ):
+            self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
+
+    def _set_hold(self, held: bool) -> None:
+        if held == self._on_hold:
+            return
+        self._on_hold = held
+        self.rtp.send_silence = not held
+        if held:
+            self.rtp.flush_tx_buffer()
+        _LOGGER.info("Remote %s the call", "held" if held else "resumed")
 
     # -- inbound requests ----------------------------------------------
     @staticmethod
@@ -826,9 +874,10 @@ class SipClient:
         # dialog of a 18x included, not just the 2xx — must echo the request's
         # Record-Route and carry a Contact the peer can route in-dialog
         # requests to. Dropping either strands a proxy/SBC outside the dialog.
-        if req.method == "INVITE" and 101 <= code < 300:
-            if record_route := req.header("Record-Route"):
-                msg += f"Record-Route: {record_route}\r\n"
+        if req.method in ("INVITE", "UPDATE") and 101 <= code < 300:
+            if req.method == "INVITE":
+                if record_route := req.header("Record-Route"):
+                    msg += f"Record-Route: {record_route}\r\n"
             msg += f"Contact: {self._contact_uri()}\r\n"
         msg += f"User-Agent: {USER_AGENT}\r\n"
         if with_sdp:
@@ -840,21 +889,67 @@ class SipClient:
             msg += "Content-Length: 0\r\n\r\n"
         return msg
 
+    def _handle_dialog_invite(self, m: sm.SipMessage) -> bool:
+        """Handle INVITE that belongs to the current dialog.
+
+        Returns True when the request was consumed (retransmission or re-INVITE).
+        """
+        if not self._d_call_id or m.header("Call-ID") != self._d_call_id:
+            return False
+        if self.state not in (SipState.INCOMING, SipState.ANSWERING, SipState.IN_CALL):
+            return False
+
+        cseq = _cseq_number(m.header("CSeq"))
+        branch = _via_branch(m.header("Via"))
+        # RFC 3261: re-INVITE raises CSeq. Same CSeq + different branch is a
+        # non-standard re-INVITE some PBXes send; treat it as renegotiation
+        # only once the call is established.
+        is_reinvite = self.state == SipState.IN_CALL and (
+            cseq > self._remote_invite_cseq
+            or (
+                cseq == self._remote_invite_cseq
+                and branch
+                and branch != self._remote_invite_branch
+            )
+        )
+        if is_reinvite:
+            self._handle_reinvite(m)
+            return True
+        if self.state == SipState.INCOMING:
+            self._send_raw(self._build_response(m, 180, "Ringing", False))
+        else:
+            # Replay 200 using this request's Via/CSeq so a lost 200 for the
+            # original INVITE or a re-INVITE still matches the transaction.
+            self._send_raw(self._build_response(m, 200, "OK", True))
+        return True
+
+    def _handle_reinvite(self, m: sm.SipMessage) -> None:
+        """Answer an in-dialog re-INVITE without restarting the media session."""
+        self._remote_invite_cseq = _cseq_number(m.header("CSeq"))
+        self._remote_invite_branch = _via_branch(m.header("Via"))
+        contact = _angle_uri(m.header("Contact"))
+        if contact:
+            self._d_remote_target = contact
+        if m.body.strip():
+            self._apply_remote_sdp(sm.parse_sdp(m.body))
+        _LOGGER.info("Accepted re-INVITE (cseq=%s)", self._remote_invite_cseq)
+        self._send_raw(self._build_response(m, 200, "OK", True))
+
+    def _handle_update(self, m: sm.SipMessage) -> None:
+        """Answer UPDATE; include an SDP answer when the request offered one."""
+        if m.body.strip():
+            self._apply_remote_sdp(sm.parse_sdp(m.body))
+            contact = _angle_uri(m.header("Contact"))
+            if contact:
+                self._d_remote_target = contact
+            self._send_raw(self._build_response(m, 200, "OK", True))
+            return
+        self._send_raw(self._build_response(m, 200, "OK", False))
+
     def _handle_request(self, m: sm.SipMessage) -> None:
         method = m.method
         if method == "INVITE":
-            # Retransmitted INVITE for the dialog we're already handling (our
-            # provisional / 200 was lost): replay the appropriate response.
-            if (
-                not self._outbound
-                and self._incoming_invite is not None
-                and m.header("Call-ID") == self._d_call_id
-                and self.state in (SipState.INCOMING, SipState.ANSWERING, SipState.IN_CALL)
-            ):
-                if self.state == SipState.INCOMING:
-                    self._send_raw(self._build_response(m, 180, "Ringing", False))
-                else:
-                    self._send_raw(self._build_response(self._incoming_invite, 200, "OK", True))
+            if self._handle_dialog_invite(m):
                 return
             caller = self._extract_caller(m)
             self.last_caller = caller
@@ -879,6 +974,10 @@ class SipClient:
                 self._d_cseq = int(m.header("CSeq").split()[0])
             except (ValueError, IndexError):
                 self._d_cseq = 1
+            self._remote_invite_cseq = self._d_cseq
+            self._remote_invite_branch = _via_branch(m.header("Via"))
+            self._on_hold = False
+            self.rtp.send_silence = True
             self._apply_remote_sdp(sm.parse_sdp(m.body))
 
             # Check for standard Intercom/Doorbell auto-answer headers
@@ -958,6 +1057,10 @@ class SipClient:
                 return
             _LOGGER.debug("DTMF '%s' received via SIP INFO", digit)
             self._on_rx_dtmf(digit)
+            return
+
+        if method == "UPDATE":
+            self._handle_update(m)
             return
 
         # OPTIONS / unknown in-dialog request: acknowledge.
@@ -1078,6 +1181,8 @@ class SipClient:
         if self._ring_timeout_handle is not None:
             self._ring_timeout_handle.cancel()
             self._ring_timeout_handle = None
+        self._on_hold = False
+        self.rtp.send_silence = True
         self._loop.create_task(self._stop_media())
         self._set_state(SipState.REGISTERED if self.registered else SipState.IDLE)
         self._emit("on_call_ended")

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -60,8 +60,10 @@ class SipCallbacks:
     on_call_ended: Callable[[], None] | None = None
     on_dtmf: Callable[[str], None] | None = None
     on_playback_done: Callable[[], None] | None = None
+    on_codec_change: Callable[[codecs.Codec], None] | None = None
 
 
+_HOLD_IPS = frozenset({"0.0.0.0", "0:0:0:0:0:0:0:0", "::"})
 _INFO_DTMF_TYPES = ("application/dtmf-relay", "application/dtmf", "audio/telephone-event")
 
 
@@ -143,6 +145,17 @@ def _via_branch(via: str) -> str:
     return match.group(1) if match else ""
 
 
+def _answer_direction(sdp: sm.SdpInfo) -> str:
+    """RFC 3264 answer direction for a remote offer, including RFC 2543 hold."""
+    if sdp.direction == "inactive":
+        return "inactive"
+    if sdp.direction == "sendonly" or sdp.connection_ip in _HOLD_IPS:
+        return "recvonly"
+    if sdp.direction == "recvonly":
+        return "sendonly"
+    return "sendrecv"
+
+
 class _SipProtocol(asyncio.DatagramProtocol):
     def __init__(self, on_packet: Callable[[bytes], None]) -> None:
         self._on_packet = on_packet
@@ -200,6 +213,7 @@ class SipClient:
         self._remote_invite_cseq = 0
         self._remote_invite_branch = ""
         self._on_hold = False
+        self._local_direction = "sendrecv"
 
         # negotiated media
         self._remote_rtp_ip = ""
@@ -535,7 +549,9 @@ class SipClient:
         self._remote_invite_cseq = 0
         self._remote_invite_branch = ""
         self._on_hold = False
+        self._local_direction = "sendrecv"
         self.rtp.send_silence = True
+        self.rtp.tx_enabled = True
         self._d_call_id = sm.gen_call_id(self._local_ip)
         self._d_local_tag = sm.gen_tag()
         self._d_branch = sm.gen_branch()
@@ -604,7 +620,7 @@ class SipClient:
         """
         sid = str(int(time.time()))
         # RFC 3264: answer sendonly with recvonly, inactive with inactive.
-        direction = "recvonly" if self._on_hold else "sendrecv"
+        direction = self._local_direction
         return (
             "v=0\r\n"
             f"o=- {sid} {sid} IN IP4 {self._local_ip}\r\n"
@@ -805,35 +821,53 @@ class SipClient:
     def _apply_remote_sdp(self, sdp: sm.SdpInfo) -> None:
         old_ip, old_port = self._remote_rtp_ip, self._remote_rtp_port
         # RFC 2543 hold uses c=0.0.0.0; keep the last real destination.
-        if sdp.connection_ip and sdp.connection_ip not in ("0.0.0.0", "0:0:0:0:0:0:0:0", "::"):
+        if sdp.connection_ip and sdp.connection_ip not in _HOLD_IPS:
             self._remote_rtp_ip = sdp.connection_ip
         if sdp.audio_port:
             self._remote_rtp_port = sdp.audio_port
-        self._codec = codecs.choose(sdp)
+
+        new_codec = codecs.keep_or_choose(self._codec, sdp)
+        codec_changed = (
+            new_codec.name != self._codec.name
+            or new_codec.payload_type != self._codec.payload_type
+        )
+        self._codec = new_codec
         self._chosen_pt = self._codec.payload_type
-        self._remote_dtmf_pt = sdp.telephone_event_pt
-
-        # Update RTP session with negotiated values
-        self.rtp.set_codec(self._codec)
-        if self._remote_dtmf_pt >= 0:
+        if sdp.telephone_event_pt >= 0:
+            self._remote_dtmf_pt = sdp.telephone_event_pt
             self.rtp.dtmf_pt = self._remote_dtmf_pt
+        if codec_changed:
+            self.rtp.set_codec(self._codec)
+            _LOGGER.info(
+                "Negotiated codec %s (pt=%s, %s Hz)",
+                self._codec.name, self._codec.payload_type, self._codec.sample_rate,
+            )
+            self._emit("on_codec_change", self._codec)
 
+        self._local_direction = _answer_direction(sdp)
         self._set_hold(sdp.is_hold)
-        # Re-INVITE / UPDATE may move the remote RTP endpoint (direct media).
-        # Retarget the existing session; do not tear it down.
-        if (
-            self._media_active
-            and self._remote_rtp_ip
-            and self._remote_rtp_port
-            and (self._remote_rtp_ip, self._remote_rtp_port) != (old_ip, old_port)
-        ):
-            self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
+        self._sync_media_endpoint(old_ip, old_port)
+
+    def _sync_media_endpoint(self, old_ip: str, old_port: int) -> None:
+        """Retarget a live RTP session, or start one once a real address arrives."""
+        if not self._remote_rtp_ip or not self._remote_rtp_port:
+            return
+        if self._media_active:
+            if (self._remote_rtp_ip, self._remote_rtp_port) != (old_ip, old_port):
+                self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
+            return
+        # Initial INVITE was offerless or c=0.0.0.0 so _start_media never
+        # bound a socket. A later re-INVITE / ACK / UPDATE can supply the
+        # real endpoint — start then, without tearing anything down.
+        if self.state in (SipState.IN_CALL, SipState.ANSWERING):
+            self._loop.create_task(self._start_media())
 
     def _set_hold(self, held: bool) -> None:
         if held == self._on_hold:
             return
         self._on_hold = held
         self.rtp.send_silence = not held
+        self.rtp.tx_enabled = not held
         if held:
             self.rtp.flush_tx_buffer()
         _LOGGER.info("Remote %s the call", "held" if held else "resumed")
@@ -901,13 +935,17 @@ class SipClient:
 
         cseq = _cseq_number(m.header("CSeq"))
         branch = _via_branch(m.header("Via"))
-        # RFC 3261: re-INVITE raises CSeq. Same CSeq + different branch is a
+        # RFC 3261: re-INVITE raises CSeq. Accept higher-CSeq while ANSWERING
+        # too: a lost ACK is often followed by a media re-INVITE before the
+        # original transaction completes. Same CSeq + different branch is a
         # non-standard re-INVITE some PBXes send; treat it as renegotiation
         # only once the call is established.
-        is_reinvite = self.state == SipState.IN_CALL and (
+        established = self.state in (SipState.IN_CALL, SipState.ANSWERING)
+        is_reinvite = established and (
             cseq > self._remote_invite_cseq
             or (
-                cseq == self._remote_invite_cseq
+                self.state == SipState.IN_CALL
+                and cseq == self._remote_invite_cseq
                 and branch
                 and branch != self._remote_invite_branch
             )
@@ -937,6 +975,16 @@ class SipClient:
 
     def _handle_update(self, m: sm.SipMessage) -> None:
         """Answer UPDATE; include an SDP answer when the request offered one."""
+        if not self._d_call_id or m.header("Call-ID") != self._d_call_id:
+            self._send_raw(
+                self._build_response(m, 481, "Call/Transaction Does Not Exist", False)
+            )
+            return
+        if self.state not in (SipState.IN_CALL, SipState.ANSWERING):
+            self._send_raw(
+                self._build_response(m, 481, "Call/Transaction Does Not Exist", False)
+            )
+            return
         if m.body.strip():
             self._apply_remote_sdp(sm.parse_sdp(m.body))
             contact = _angle_uri(m.header("Contact"))
@@ -977,7 +1025,9 @@ class SipClient:
             self._remote_invite_cseq = self._d_cseq
             self._remote_invite_branch = _via_branch(m.header("Via"))
             self._on_hold = False
+            self._local_direction = "sendrecv"
             self.rtp.send_silence = True
+            self.rtp.tx_enabled = True
             self._apply_remote_sdp(sm.parse_sdp(m.body))
 
             # Check for standard Intercom/Doorbell auto-answer headers
@@ -1022,6 +1072,12 @@ class SipClient:
             return
 
         if method == "ACK":
+            if self._d_call_id and m.header("Call-ID") != self._d_call_id:
+                return
+            # Offerless INVITE/re-INVITE: our 200 was the offer; the answer
+            # arrives in the ACK body (RFC 3261 §13.2.1 / §14.1).
+            if m.body.strip():
+                self._apply_remote_sdp(sm.parse_sdp(m.body))
             if self.state == SipState.ANSWERING:
                 self._set_state(SipState.IN_CALL)
                 _LOGGER.info("Call connected (inbound)")
@@ -1182,7 +1238,9 @@ class SipClient:
             self._ring_timeout_handle.cancel()
             self._ring_timeout_handle = None
         self._on_hold = False
+        self._local_direction = "sendrecv"
         self.rtp.send_silence = True
+        self.rtp.tx_enabled = True
         self._loop.create_task(self._stop_media())
         self._set_state(SipState.REGISTERED if self.registered else SipState.IDLE)
         self._emit("on_call_ended")

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -825,9 +825,10 @@ class SipClient:
             self._remote_rtp_port = sdp.audio_port
 
         old_codec = self._codec
+        in_dialog = self._sdp_negotiated
         # First SDP of a dialog picks the preferred codec. Later re-INVITE /
         # UPDATE keep the current one when it is still offered.
-        if self._sdp_negotiated:
+        if in_dialog:
             new_codec = codecs.keep_or_choose(self._codec, sdp)
         else:
             new_codec = codecs.choose(sdp)
@@ -847,12 +848,17 @@ class SipClient:
             self.rtp.set_codec(self._codec)
             if old_codec.sample_rate != new_codec.sample_rate:
                 self.rtp.flush_tx_buffer()
-                self._cancel_source()
-            _LOGGER.info(
-                "Negotiated codec %s (pt=%s, %s Hz)",
-                self._codec.name, self._codec.payload_type, self._codec.sample_rate,
-            )
-            self._emit("on_codec_change", self._codec)
+                if self._tx_source_task is not None:
+                    self._cancel_source()
+                    # Unblock Assist/IVR waiters; CancelledError skips the
+                    # normal on_playback_done at the end of _run_source.
+                    self._emit("on_playback_done")
+            if in_dialog:
+                _LOGGER.info(
+                    "Negotiated codec %s (pt=%s, %s Hz)",
+                    self._codec.name, self._codec.payload_type, self._codec.sample_rate,
+                )
+                self._emit("on_codec_change", self._codec)
 
         self._local_direction = _answer_direction(sdp)
         self._set_hold(sdp.is_hold)

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -221,6 +221,7 @@ class SipClient:
         self._codec: codecs.Codec = codecs.DEFAULT
         self._chosen_pt = self._codec.payload_type
         self._remote_dtmf_pt = -1
+        self._sdp_negotiated = False
         self._media_active = False
 
         self.rtp = RtpSession()
@@ -548,10 +549,7 @@ class SipClient:
         self._accepted_dialog_to = ""
         self._remote_invite_cseq = 0
         self._remote_invite_branch = ""
-        self._on_hold = False
-        self._local_direction = "sendrecv"
-        self.rtp.send_silence = True
-        self.rtp.tx_enabled = True
+        self._begin_dialog_media()
         self._d_call_id = sm.gen_call_id(self._local_ip)
         self._d_local_tag = sm.gen_tag()
         self._d_branch = sm.gen_branch()
@@ -826,18 +824,30 @@ class SipClient:
         if sdp.audio_port:
             self._remote_rtp_port = sdp.audio_port
 
-        new_codec = codecs.keep_or_choose(self._codec, sdp)
+        old_codec = self._codec
+        # First SDP of a dialog picks the preferred codec. Later re-INVITE /
+        # UPDATE keep the current one when it is still offered.
+        if self._sdp_negotiated:
+            new_codec = codecs.keep_or_choose(self._codec, sdp)
+        else:
+            new_codec = codecs.choose(sdp)
         codec_changed = (
-            new_codec.name != self._codec.name
-            or new_codec.payload_type != self._codec.payload_type
+            new_codec.name != old_codec.name
+            or new_codec.payload_type != old_codec.payload_type
         )
         self._codec = new_codec
         self._chosen_pt = self._codec.payload_type
-        if sdp.telephone_event_pt >= 0:
+        if sdp.valid:
+            self._sdp_negotiated = True
+            # Including -1: a new offer without telephone-event must not
+            # inherit the previous call's DTMF payload type.
             self._remote_dtmf_pt = sdp.telephone_event_pt
             self.rtp.dtmf_pt = self._remote_dtmf_pt
         if codec_changed:
             self.rtp.set_codec(self._codec)
+            if old_codec.sample_rate != new_codec.sample_rate:
+                self.rtp.flush_tx_buffer()
+                self._cancel_source()
             _LOGGER.info(
                 "Negotiated codec %s (pt=%s, %s Hz)",
                 self._codec.name, self._codec.payload_type, self._codec.sample_rate,
@@ -847,6 +857,20 @@ class SipClient:
         self._local_direction = _answer_direction(sdp)
         self._set_hold(sdp.is_hold)
         self._sync_media_endpoint(old_ip, old_port)
+
+    def _begin_dialog_media(self) -> None:
+        """Clear per-call media state so the previous dialog cannot leak."""
+        self._codec = codecs.DEFAULT
+        self._chosen_pt = self._codec.payload_type
+        self._remote_dtmf_pt = -1
+        self.rtp.dtmf_pt = -1
+        self._sdp_negotiated = False
+        self._remote_rtp_ip = ""
+        self._remote_rtp_port = 0
+        self._on_hold = False
+        self._local_direction = "sendrecv"
+        self.rtp.send_silence = True
+        self.rtp.clear_tx_pause()
 
     def _sync_media_endpoint(self, old_ip: str, old_port: int) -> None:
         """Retarget a live RTP session, or start one once a real address arrives."""
@@ -867,9 +891,7 @@ class SipClient:
             return
         self._on_hold = held
         self.rtp.send_silence = not held
-        self.rtp.tx_enabled = not held
-        if held:
-            self.rtp.flush_tx_buffer()
+        self.rtp.set_tx_enabled(not held)
         _LOGGER.info("Remote %s the call", "held" if held else "resumed")
 
     # -- inbound requests ----------------------------------------------
@@ -1024,10 +1046,7 @@ class SipClient:
                 self._d_cseq = 1
             self._remote_invite_cseq = self._d_cseq
             self._remote_invite_branch = _via_branch(m.header("Via"))
-            self._on_hold = False
-            self._local_direction = "sendrecv"
-            self.rtp.send_silence = True
-            self.rtp.tx_enabled = True
+            self._begin_dialog_media()
             self._apply_remote_sdp(sm.parse_sdp(m.body))
 
             # Check for standard Intercom/Doorbell auto-answer headers
@@ -1240,7 +1259,7 @@ class SipClient:
         self._on_hold = False
         self._local_direction = "sendrecv"
         self.rtp.send_silence = True
-        self.rtp.tx_enabled = True
+        self.rtp.clear_tx_pause()
         self._loop.create_task(self._stop_media())
         self._set_state(SipState.REGISTERED if self.registered else SipState.IDLE)
         self._emit("on_call_ended")

--- a/custom_components/sip/sip_client/sip_message.py
+++ b/custom_components/sip/sip_client/sip_message.py
@@ -35,8 +35,17 @@ class SdpInfo:
     pcma_pt: int = -1
     g722_pt: int = -1
     telephone_event_pt: int = -1
+    # sendrecv / sendonly / recvonly / inactive. Last matching a= line wins.
+    direction: str = "sendrecv"
     # All payload types seen on m=audio or a=rtpmap (audio + telephone-event).
     offered_pts: set[int] = field(default_factory=set)
+
+    @property
+    def is_hold(self) -> bool:
+        """RFC 3264 sendonly/inactive, or RFC 2543 c=0.0.0.0 hold."""
+        if self.connection_ip in ("0.0.0.0", "0:0:0:0:0:0:0:0", "::"):
+            return True
+        return self.direction in ("sendonly", "inactive")
 
 
 # Compact header mapping (RFC 3261 Section 7.3.3)
@@ -185,6 +194,8 @@ def parse_sdp(body: str) -> SdpInfo:
                 info.pcma_pt = pt
             elif "g722" in lower:
                 info.g722_pt = pt
+        elif line in ("a=sendrecv", "a=sendonly", "a=recvonly", "a=inactive"):
+            info.direction = line[2:]
     return info
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -201,7 +201,7 @@ ruff check custom_components/     # 린트
 
 ## P0 — 통화가 끊기는 결함 (릴리스 블로커)
 
-### [ ] P0-1. in-dialog re-INVITE 정상 응답
+### [x] P0-1. in-dialog re-INVITE 정상 응답
 
 **근거** §1.3-1. 확인된 결함. 기본 설정 PBX에서 통화가 끊기는 가장 유력한 경로.
 
@@ -241,6 +241,14 @@ ruff check custom_components/     # 린트
 - re-INVITE의 SDP가 원격 RTP 주소를 바꾸면 `rtp.set_remote`가 새 값으로 호출되고
   `rtp.stop()`이 호출되지 **않는다**.
 - hold(`a=sendonly`) → 재개 왕복 후 송신이 복구된다.
+
+**추가된 테스트**
+- `test_inbound_reinvite_answers_with_new_transaction`
+- `test_outbound_reinvite_is_not_busy_here`
+- `test_invite_retransmission_replays_prior_response`
+- `test_reinvite_hold_and_resume_toggles_tx`
+- `test_update_with_sdp_returns_answer`
+- `test_parse_sdp_hold_attributes`
 
 **리스크** 재전송과 re-INVITE의 구분을 CSeq로만 하면 CSeq를 증가시키지 않는 비표준
 구현에서 오판할 수 있다. Via branch 비교를 보조 조건으로 둔다.

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -429,6 +429,17 @@ def test_codecs_keep_or_choose_prefers_current_if_still_offered():
     assert switched.payload_type == 8
 
 
+def test_codecs_keep_or_choose_dynamic_pt_matches_by_name():
+    pcmu96 = codecs.PCMU.with_payload_type(96)
+    still_pcmu = codecs.keep_or_choose(pcmu96, _sdp({96, 97}, pcmu=96))
+    assert still_pcmu.name == "PCMU"
+    assert still_pcmu.payload_type == 96
+    # Same number, different codec: must not keep PCMU@96.
+    switched = codecs.keep_or_choose(pcmu96, _sdp({96}, g722=96))
+    assert switched.name == "G722"
+    assert switched.payload_type == 96
+
+
 def test_codecs_sdp_offer_includes_g722():
     assert codecs.sdp_media_line(7078) == "m=audio 7078 RTP/AVP 9 0 8 101\r\n"
     assert codecs.sdp_rtpmaps() == (
@@ -1489,6 +1500,107 @@ def test_reinvite_starts_media_if_never_started():
     assert port == 5300
 
 
+def test_telephone_event_pt_does_not_leak_across_calls():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.registered = True
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        with_te = _invite_request(
+            call_id="first@example",
+            pts="8 101",
+            rtpmap="a=rtpmap:8 PCMA/8000\r\na=rtpmap:101 telephone-event/8000\r\n",
+        )
+        without_te = _invite_request(call_id="second@example", branch="z9hG4bKsecond")
+        with patch.object(client, "_send_raw"):
+            client._handle_request(with_te)
+            first_pt = client._remote_dtmf_pt, client.rtp.dtmf_pt
+            client._end_call()
+            await asyncio.sleep(0)
+            client.state = sip_client.SipState.REGISTERED
+            client._handle_request(without_te)
+            second_pt = client._remote_dtmf_pt, client.rtp.dtmf_pt
+        return first_pt, second_pt
+
+    first_pt, second_pt = asyncio.run(run())
+    assert first_pt == (101, 101)
+    assert second_pt == (-1, -1)
+
+
+def test_new_call_chooses_preferred_codec_not_previous():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.registered = True
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        pcma_only = _invite_request(call_id="pcma@example")
+        g722_offer = _invite_request(
+            call_id="g722@example",
+            branch="z9hG4bKg722",
+            pts="9 8",
+            rtpmap="a=rtpmap:9 G722/8000\r\na=rtpmap:8 PCMA/8000\r\n",
+        )
+        with patch.object(client, "_send_raw"):
+            client._handle_request(pcma_only)
+            first = client.codec.name
+            client._end_call()
+            await asyncio.sleep(0)
+            client.state = sip_client.SipState.REGISTERED
+            client._handle_request(g722_offer)
+            second = client.codec.name
+        return first, second
+
+    first, second = asyncio.run(run())
+    assert first == "PCMA"
+    assert second == "G722"
+
+
+def test_sample_rate_change_flushes_tx_and_cancels_source():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        orig = _invite_request(
+            pts="9",
+            rtpmap="a=rtpmap:9 G722/8000\r\n",
+        )
+        with patch.object(client, "_send_raw"):
+            client._handle_request(orig)
+        client.state = sip_client.SipState.IN_CALL
+        client._media_active = True
+        client.rtp._tx_buffer.extend(b"\x00" * 640)
+        task = MagicMock()
+        client._tx_source_task = task
+        drop = _invite_request(
+            cseq=2,
+            branch="z9hG4bKdrop",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+        )
+        with patch.object(client, "_send_raw"):
+            client._handle_request(drop)
+        return (
+            client.codec.name,
+            bytes(client.rtp._tx_buffer),
+            client._tx_source_task,
+            task.cancel.called,
+        )
+
+    name, buffered, source_task, cancelled = asyncio.run(run())
+    assert name == "PCMA"
+    assert buffered == b""
+    assert source_task is None
+    assert cancelled is True
+
+
 def test_update_with_sdp_returns_answer():
     if sip_client is None:
         return
@@ -1679,6 +1791,26 @@ def test_rtp_flush_tx_buffer():
         assert not session._tx_buffer
 
     asyncio.run(run())
+
+
+def test_rtp_hold_resume_catches_up_timestamp():
+    async def run():
+        session = rtp_session.RtpSession()
+        session._timestamp = 1000
+        session._ts_increment = 160
+        session._first_packet = False
+        clock = {"t": 10.0}
+        session._loop.time = lambda: clock["t"]
+        session.set_tx_enabled(False)
+        clock["t"] = 12.0
+        session.set_tx_enabled(True)
+        return session._timestamp, session._first_packet, session.tx_enabled
+
+    timestamp, marked, enabled = asyncio.run(run())
+    # 2.0 s / 20 ms = 100 frames × 160 ticks.
+    assert timestamp == 1000 + 100 * 160
+    assert marked is True
+    assert enabled is True
 
 
 def test_rtp_g722_frame_size_and_timestamp():

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -416,6 +416,19 @@ def test_codecs_choose_dynamic_pt_by_name():
     assert chosen.name == "G722" and chosen.payload_type == 110
 
 
+def test_codecs_keep_or_choose_prefers_current_if_still_offered():
+    current = codecs.G722
+    # Refresh still lists G.722: keep it rather than rebuilding encoder state.
+    kept = codecs.keep_or_choose(current, _sdp({9, 0, 8}, pcmu=0, pcma=8, g722=9))
+    assert kept is current
+    # Offerless / no audio payloads: keep current.
+    assert codecs.keep_or_choose(current, sm.SdpInfo()) is current
+    # Remote dropped G.722: fall back to the remaining offer.
+    switched = codecs.keep_or_choose(current, _sdp({8}, pcma=8))
+    assert switched.name == "PCMA"
+    assert switched.payload_type == 8
+
+
 def test_codecs_sdp_offer_includes_g722():
     assert codecs.sdp_media_line(7078) == "m=audio 7078 RTP/AVP 9 0 8 101\r\n"
     assert codecs.sdp_rtpmaps() == (
@@ -990,12 +1003,12 @@ def test_ringing_response_establishes_early_dialog():
 
 
 # ------------------------------------------------------- in-dialog re-INVITE
-def _sdp_body(ip="198.51.100.10", port=4000, extra=""):
+def _sdp_body(ip="198.51.100.10", port=4000, extra="", pts="8", rtpmap="a=rtpmap:8 PCMA/8000\r\n"):
     return (
         "v=0\r\n"
         f"c=IN IP4 {ip}\r\n"
-        f"m=audio {port} RTP/AVP 8\r\n"
-        "a=rtpmap:8 PCMA/8000\r\n"
+        f"m=audio {port} RTP/AVP {pts}\r\n"
+        f"{rtpmap}"
         f"{extra}"
     )
 
@@ -1011,8 +1024,13 @@ def _invite_request(
     sdp_ip="198.51.100.10",
     sdp_port=4000,
     extra_sdp="",
+    body=None,
+    pts="8",
+    rtpmap="a=rtpmap:8 PCMA/8000\r\n",
 ):
-    body = _sdp_body(sdp_ip, sdp_port, extra_sdp)
+    if body is None:
+        body = _sdp_body(sdp_ip, sdp_port, extra_sdp, pts=pts, rtpmap=rtpmap)
+    ctype = "Content-Type: application/sdp\r\n" if body else ""
     return sm.parse_sip_message(
         "INVITE sip:alice@example SIP/2.0\r\n"
         f"Via: SIP/2.0/UDP pbx.example;branch={branch}\r\n"
@@ -1021,7 +1039,7 @@ def _invite_request(
         f"Contact: {contact}\r\n"
         f"Call-ID: {call_id}\r\n"
         f"CSeq: {cseq} INVITE\r\n"
-        "Content-Type: application/sdp\r\n"
+        f"{ctype}"
         f"Content-Length: {len(body)}\r\n\r\n{body}"
     )
 
@@ -1203,6 +1221,272 @@ def test_reinvite_hold_and_resume_toggles_tx():
     assert resumed[1] is False
     assert "a=sendrecv" in resumed[2]
     assert state == sip_client.SipState.IN_CALL
+
+
+def test_reinvite_inactive_answers_inactive():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        hold = _invite_request(
+            cseq=2,
+            branch="z9hG4bKinact",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            extra_sdp="a=inactive\r\n",
+        )
+        with patch.object(client, "_send_raw") as send:
+            client._handle_request(hold)
+        return send.call_args.args[0], client.rtp.tx_enabled, client._local_direction
+
+    sent, tx_enabled, direction = asyncio.run(run())
+    assert sent.startswith("SIP/2.0 200 OK")
+    assert "a=inactive" in sent
+    assert "a=recvonly" not in sent
+    assert tx_enabled is False
+    assert direction == "inactive"
+
+
+def test_hold_drops_queued_tx_audio():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        client.rtp._transport = object()
+        client.rtp.tx_enabled = True
+        hold = _invite_request(
+            cseq=2,
+            branch="z9hG4bKholdtx",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            extra_sdp="a=sendonly\r\n",
+        )
+        with patch.object(client, "_send_raw"):
+            client._handle_request(hold)
+        client.rtp.push_tx_audio(b"\x00" * 320)
+        return client.rtp.tx_enabled, bytes(client.rtp._tx_buffer)
+
+    tx_enabled, buffered = asyncio.run(run())
+    assert tx_enabled is False
+    assert buffered == b""
+
+
+def test_answering_reinvite_applies_new_sdp():
+    """A lost ACK followed by CSeq+1 re-INVITE must not replay the original 200."""
+    if sip_client is None:
+        return
+
+    async def run():
+        incoming = []
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example"),
+            sip_client.SipCallbacks(on_incoming_call=incoming.append),
+        )
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        orig = _invite_request()
+        with patch.object(client, "_send_raw"):
+            client._handle_request(orig)
+        client.state = sip_client.SipState.ANSWERING
+        client._media_active = True
+        reinvite = _invite_request(
+            cseq=2,
+            branch="z9hG4bKans-reinv",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            sdp_ip="203.0.113.70",
+            sdp_port=5100,
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client.rtp, "set_remote") as set_remote,
+        ):
+            client._handle_request(reinvite)
+        return send.call_args.args[0], set_remote, client.state, incoming
+
+    sent, set_remote, state, incoming = asyncio.run(run())
+    assert sent.startswith("SIP/2.0 200 OK")
+    assert "CSeq: 2 INVITE\r\n" in sent
+    assert "branch=z9hG4bKans-reinv" in sent
+    set_remote.assert_called_once_with("203.0.113.70", 5100)
+    assert state == sip_client.SipState.ANSWERING
+    assert incoming == ["bob"]
+
+
+def test_offerless_reinvite_applies_ack_sdp():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        reinvite = _invite_request(
+            cseq=2,
+            branch="z9hG4bKofferless",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            body="",
+        )
+        ack_body = _sdp_body("203.0.113.80", 5200)
+        ack = sm.parse_sip_message(
+            "ACK sip:alice@example SIP/2.0\r\n"
+            "Via: SIP/2.0/UDP pbx.example;branch=z9hG4bKack\r\n"
+            "From: <sip:bob@example>;tag=remote\r\n"
+            f"To: <sip:alice@example>;tag={client._d_local_tag}\r\n"
+            "Call-ID: dlg@example\r\n"
+            "CSeq: 2 ACK\r\n"
+            "Content-Type: application/sdp\r\n"
+            f"Content-Length: {len(ack_body)}\r\n\r\n{ack_body}"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client.rtp, "set_remote") as set_remote,
+        ):
+            client._handle_request(reinvite)
+            offer = send.call_args.args[0]
+            client._handle_request(ack)
+        return offer, set_remote, client._remote_rtp_ip, client._remote_rtp_port
+
+    offer, set_remote, ip, port = asyncio.run(run())
+    assert offer.startswith("SIP/2.0 200 OK")
+    assert "Content-Type: application/sdp" in offer
+    set_remote.assert_called_once_with("203.0.113.80", 5200)
+    assert ip == "203.0.113.80"
+    assert port == 5200
+
+
+def test_reinvite_keeps_codec_when_still_offered():
+    if sip_client is None:
+        return
+
+    async def run():
+        incoming = []
+        changed = []
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example"),
+            sip_client.SipCallbacks(
+                on_incoming_call=incoming.append,
+                on_codec_change=changed.append,
+            ),
+        )
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        g722_rtpmap = (
+            "a=rtpmap:9 G722/8000\r\n"
+            "a=rtpmap:8 PCMA/8000\r\n"
+        )
+        orig = _invite_request(pts="9 8", rtpmap=g722_rtpmap)
+        with patch.object(client, "_send_raw"):
+            client._handle_request(orig)
+        client.state = sip_client.SipState.IN_CALL
+        client._media_active = True
+        with patch.object(client.rtp, "set_codec") as set_codec:
+            refresh = _invite_request(
+                cseq=2,
+                branch="z9hG4bKkeep",
+                to=f"<sip:alice@example>;tag={client._d_local_tag}",
+                pts="9 8",
+                rtpmap=g722_rtpmap,
+            )
+            client._handle_request(refresh)
+        return client.codec.name, set_codec.call_count, [c.name for c in changed]
+
+    name, set_codec_calls, changed_names = asyncio.run(run())
+    assert name == "G722"
+    assert set_codec_calls == 0
+    assert changed_names == ["G722"]  # initial negotiation only
+
+
+def test_reinvite_notifies_codec_change():
+    if sip_client is None:
+        return
+
+    async def run():
+        changed = []
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example"),
+            sip_client.SipCallbacks(on_codec_change=changed.append),
+        )
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        orig = _invite_request(
+            pts="9 8",
+            rtpmap="a=rtpmap:9 G722/8000\r\na=rtpmap:8 PCMA/8000\r\n",
+        )
+        with patch.object(client, "_send_raw"):
+            client._handle_request(orig)
+        client.state = sip_client.SipState.IN_CALL
+        client._media_active = True
+        with patch.object(client.rtp, "set_codec") as set_codec:
+            drop_g722 = _invite_request(
+                cseq=2,
+                branch="z9hG4bKpcma",
+                to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            )
+            client._handle_request(drop_g722)
+        return client.codec.name, set_codec.call_count, [c.name for c in changed]
+
+    name, set_codec_calls, changed_names = asyncio.run(run())
+    assert name == "PCMA"
+    assert set_codec_calls == 1
+    assert changed_names == ["G722", "PCMA"]
+
+
+def test_update_wrong_call_id_is_481():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        body = _sdp_body("203.0.113.9", 7000)
+        update = sm.parse_sip_message(
+            "UPDATE sip:alice@example SIP/2.0\r\n"
+            "Via: SIP/2.0/UDP pbx.example;branch=z9hG4bKupd\r\n"
+            "From: <sip:bob@example>;tag=remote\r\n"
+            "To: <sip:alice@example>;tag=local\r\n"
+            "Call-ID: other-dialog@example\r\n"
+            "CSeq: 4 UPDATE\r\n"
+            "Content-Type: application/sdp\r\n"
+            f"Content-Length: {len(body)}\r\n\r\n{body}"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client.rtp, "set_remote") as set_remote,
+        ):
+            client._handle_request(update)
+        return send.call_args.args[0], set_remote, client._remote_rtp_ip
+
+    sent, set_remote, ip = asyncio.run(run())
+    assert sent.startswith("SIP/2.0 481")
+    set_remote.assert_not_called()
+    assert ip == "198.51.100.10"
+
+
+def test_reinvite_starts_media_if_never_started():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        client._media_active = False
+        client._remote_rtp_ip = ""
+        client._remote_rtp_port = 0
+        reinvite = _invite_request(
+            cseq=2,
+            branch="z9hG4bKlate-media",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            sdp_ip="203.0.113.90",
+            sdp_port=5300,
+        )
+        with (
+            patch.object(client, "_send_raw"),
+            patch.object(client, "_start_media", new_callable=AsyncMock) as start_media,
+        ):
+            client._handle_request(reinvite)
+            await asyncio.sleep(0)
+        return start_media.await_count, client._remote_rtp_ip, client._remote_rtp_port
+
+    starts, ip, port = asyncio.run(run())
+    assert starts == 1
+    assert ip == "203.0.113.90"
+    assert port == 5300
 
 
 def test_update_with_sdp_returns_answer():

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -358,6 +358,26 @@ def test_parse_sdp():
     assert sdp.offered_pts == {0, 8, 101}
 
 
+def test_parse_sdp_hold_attributes():
+    sendonly = sm.parse_sdp(
+        "c=IN IP4 192.168.0.5\r\nm=audio 4002 RTP/AVP 8\r\na=sendonly\r\n"
+    )
+    assert sendonly.direction == "sendonly"
+    assert sendonly.is_hold
+    inactive = sm.parse_sdp(
+        "c=IN IP4 192.168.0.5\r\nm=audio 4002 RTP/AVP 8\r\na=inactive\r\n"
+    )
+    assert inactive.is_hold
+    rfc2543 = sm.parse_sdp("c=IN IP4 0.0.0.0\r\nm=audio 4002 RTP/AVP 8\r\n")
+    assert rfc2543.connection_ip == "0.0.0.0"
+    assert rfc2543.is_hold
+    resume = sm.parse_sdp(
+        "c=IN IP4 192.168.0.5\r\nm=audio 4002 RTP/AVP 8\r\na=sendrecv\r\n"
+    )
+    assert resume.direction == "sendrecv"
+    assert not resume.is_hold
+
+
 def test_parse_sdp_offered_pts_from_rtpmap_only():
     # Dynamic PT advertised only via rtpmap still lands in offered_pts.
     body = (
@@ -967,6 +987,256 @@ def test_ringing_response_establishes_early_dialog():
     # 100 Trying is not dialog-establishing and must stay bare.
     assert "Record-Route:" not in trying
     assert "Contact:" not in trying
+
+
+# ------------------------------------------------------- in-dialog re-INVITE
+def _sdp_body(ip="198.51.100.10", port=4000, extra=""):
+    return (
+        "v=0\r\n"
+        f"c=IN IP4 {ip}\r\n"
+        f"m=audio {port} RTP/AVP 8\r\n"
+        "a=rtpmap:8 PCMA/8000\r\n"
+        f"{extra}"
+    )
+
+
+def _invite_request(
+    *,
+    call_id="dlg@example",
+    cseq=1,
+    branch="z9hG4bKorig",
+    frm="<sip:bob@example>;tag=remote",
+    to="<sip:alice@example>",
+    contact="<sip:bob@target.example>",
+    sdp_ip="198.51.100.10",
+    sdp_port=4000,
+    extra_sdp="",
+):
+    body = _sdp_body(sdp_ip, sdp_port, extra_sdp)
+    return sm.parse_sip_message(
+        "INVITE sip:alice@example SIP/2.0\r\n"
+        f"Via: SIP/2.0/UDP pbx.example;branch={branch}\r\n"
+        f"From: {frm}\r\n"
+        f"To: {to}\r\n"
+        f"Contact: {contact}\r\n"
+        f"Call-ID: {call_id}\r\n"
+        f"CSeq: {cseq} INVITE\r\n"
+        "Content-Type: application/sdp\r\n"
+        f"Content-Length: {len(body)}\r\n\r\n{body}"
+    )
+
+
+def _inbound_in_call():
+    """Drive an inbound INVITE through to IN_CALL and return (client, orig)."""
+    incoming = []
+    client = sip_client.SipClient(
+        sip_client.SipConfig(server="pbx.example"),
+        sip_client.SipCallbacks(on_incoming_call=incoming.append),
+    )
+    client.state = sip_client.SipState.REGISTERED
+    client._local_ip = "192.0.2.1"
+    client._local_port = 5060
+    orig = _invite_request()
+    with patch.object(client, "_send_raw"):
+        client._handle_request(orig)
+    client.state = sip_client.SipState.IN_CALL
+    client._media_active = True
+    return client, orig, incoming
+
+
+def _outbound_in_call():
+    incoming = []
+    client = sip_client.SipClient(
+        sip_client.SipConfig(server="pbx.example"),
+        sip_client.SipCallbacks(on_incoming_call=incoming.append),
+    )
+    client._local_ip = "192.0.2.1"
+    client._local_port = 5060
+    client._outbound = True
+    client._d_call_id = "out@example"
+    client._d_local_tag = "local"
+    client._d_local = "<sip:alice@example>;tag=local"
+    client._d_remote = "<sip:bob@example>;tag=remote"
+    client._d_remote_target = "sip:bob@target.example"
+    client._remote_rtp_ip = "198.51.100.10"
+    client._remote_rtp_port = 4000
+    client.last_caller = "keep-me"
+    client.registered = True
+    client.state = sip_client.SipState.IN_CALL
+    client._media_active = True
+    return client, incoming
+
+
+def test_inbound_reinvite_answers_with_new_transaction():
+    """re-INVITE 200 must echo the re-INVITE Via branch and CSeq, not the original."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client, orig, incoming = _inbound_in_call()
+        last_caller = client.last_caller
+        reinvite = _invite_request(
+            cseq=2,
+            branch="z9hG4bKreinv",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            contact="<sip:bob@new.example>",
+            sdp_ip="203.0.113.50",
+            sdp_port=5000,
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client.rtp, "set_remote") as set_remote,
+            patch.object(client.rtp, "stop", new_callable=AsyncMock) as rtp_stop,
+        ):
+            client._handle_request(reinvite)
+        return client, orig, incoming, last_caller, send, set_remote, rtp_stop
+
+    client, orig, incoming, last_caller, send, set_remote, rtp_stop = asyncio.run(run())
+    sent = send.call_args_list[0].args[0]
+    assert sent.startswith("SIP/2.0 200 OK")
+    assert "CSeq: 2 INVITE\r\n" in sent
+    assert "branch=z9hG4bKreinv" in sent
+    assert "CSeq: 1 INVITE\r\n" not in sent
+    assert "branch=z9hG4bKorig" not in sent
+    assert "Content-Type: application/sdp" in sent
+    assert "m=audio" in sent
+    assert client.last_caller == last_caller
+    assert client.state == sip_client.SipState.IN_CALL
+    assert client._d_remote_target == "sip:bob@new.example"
+    assert incoming == ["bob"]  # original only; re-INVITE must not re-emit
+    set_remote.assert_called_once_with("203.0.113.50", 5000)
+    rtp_stop.assert_not_called()
+
+
+def test_outbound_reinvite_is_not_busy_here():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, incoming = _outbound_in_call()
+        reinvite = _invite_request(
+            call_id="out@example",
+            cseq=1,
+            branch="z9hG4bKout-reinv",
+            to="<sip:alice@example>;tag=local",
+            sdp_ip="203.0.113.8",
+            sdp_port=6000,
+        )
+        with patch.object(client, "_send_raw") as send:
+            client._handle_request(reinvite)
+        return client, incoming, [c.args[0] for c in send.call_args_list]
+
+    client, incoming, sent = asyncio.run(run())
+    assert sent and sent[0].startswith("SIP/2.0 200 OK")
+    assert "486 Busy Here" not in sent[0]
+    assert "Content-Type: application/sdp" in sent[0]
+    assert "CSeq: 1 INVITE\r\n" in sent[0]
+    assert "branch=z9hG4bKout-reinv" in sent[0]
+    assert client.last_caller == "keep-me"
+    assert client.state == sip_client.SipState.IN_CALL
+    assert incoming == []
+
+
+def test_invite_retransmission_replays_prior_response():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        orig = _invite_request()
+        with patch.object(client, "_send_raw") as send:
+            client._handle_request(orig)
+            ringing = [c.args[0] for c in send.call_args_list]
+            send.reset_mock()
+            client._handle_request(orig)
+            replay = [c.args[0] for c in send.call_args_list]
+            client.state = sip_client.SipState.IN_CALL
+            send.reset_mock()
+            client._handle_request(orig)
+            in_call_replay = [c.args[0] for c in send.call_args_list]
+        return ringing, replay, in_call_replay
+
+    ringing, replay, in_call_replay = asyncio.run(run())
+    assert any(s.startswith("SIP/2.0 180 Ringing") for s in ringing)
+    assert replay and replay[0].startswith("SIP/2.0 180 Ringing")
+    assert "CSeq: 1 INVITE\r\n" in replay[0]
+    assert "branch=z9hG4bKorig" in replay[0]
+    assert in_call_replay and in_call_replay[0].startswith("SIP/2.0 200 OK")
+    assert "CSeq: 1 INVITE\r\n" in in_call_replay[0]
+    assert "branch=z9hG4bKorig" in in_call_replay[0]
+
+
+def test_reinvite_hold_and_resume_toggles_tx():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        hold = _invite_request(
+            cseq=2,
+            branch="z9hG4bKhold",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            extra_sdp="a=sendonly\r\n",
+        )
+        resume = _invite_request(
+            cseq=3,
+            branch="z9hG4bKresume",
+            to=f"<sip:alice@example>;tag={client._d_local_tag}",
+            extra_sdp="a=sendrecv\r\n",
+        )
+        with patch.object(client, "_send_raw") as send:
+            client._handle_request(hold)
+            held = client.rtp.send_silence, client._on_hold, send.call_args.args[0]
+            send.reset_mock()
+            client._handle_request(resume)
+            resumed = client.rtp.send_silence, client._on_hold, send.call_args.args[0]
+        return held, resumed, client.state
+
+    held, resumed, state = asyncio.run(run())
+    assert held[0] is False
+    assert held[1] is True
+    assert held[2].startswith("SIP/2.0 200 OK")
+    assert "a=recvonly" in held[2]
+    assert resumed[0] is True
+    assert resumed[1] is False
+    assert "a=sendrecv" in resumed[2]
+    assert state == sip_client.SipState.IN_CALL
+
+
+def test_update_with_sdp_returns_answer():
+    if sip_client is None:
+        return
+
+    async def run():
+        client, _, _ = _inbound_in_call()
+        body = _sdp_body("203.0.113.9", 7000)
+        update = sm.parse_sip_message(
+            "UPDATE sip:alice@example SIP/2.0\r\n"
+            "Via: SIP/2.0/UDP pbx.example;branch=z9hG4bKupd\r\n"
+            "From: <sip:bob@example>;tag=remote\r\n"
+            f"To: <sip:alice@example>;tag={client._d_local_tag}\r\n"
+            "Call-ID: dlg@example\r\n"
+            "CSeq: 4 UPDATE\r\n"
+            "Content-Type: application/sdp\r\n"
+            f"Content-Length: {len(body)}\r\n\r\n{body}"
+        )
+        with (
+            patch.object(client, "_send_raw") as send,
+            patch.object(client.rtp, "set_remote") as set_remote,
+            patch.object(client.rtp, "stop", new_callable=AsyncMock) as rtp_stop,
+        ):
+            client._handle_request(update)
+        return send.call_args.args[0], set_remote, rtp_stop, client.state
+
+    sent, set_remote, rtp_stop, state = asyncio.run(run())
+    assert sent.startswith("SIP/2.0 200 OK")
+    assert "CSeq: 4 UPDATE\r\n" in sent
+    assert "Content-Type: application/sdp" in sent
+    set_remote.assert_called_once_with("203.0.113.9", 7000)
+    rtp_stop.assert_not_called()
+    assert state == sip_client.SipState.IN_CALL
 
 
 # ------------------------------------------------------- RFC 2833 RX

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1402,7 +1402,7 @@ def test_reinvite_keeps_codec_when_still_offered():
     name, set_codec_calls, changed_names = asyncio.run(run())
     assert name == "G722"
     assert set_codec_calls == 0
-    assert changed_names == ["G722"]  # initial negotiation only
+    assert changed_names == []
 
 
 def test_reinvite_notifies_codec_change():
@@ -1437,7 +1437,7 @@ def test_reinvite_notifies_codec_change():
     name, set_codec_calls, changed_names = asyncio.run(run())
     assert name == "PCMA"
     assert set_codec_calls == 1
-    assert changed_names == ["G722", "PCMA"]
+    assert changed_names == ["PCMA"]
 
 
 def test_update_wrong_call_id_is_481():
@@ -1566,7 +1566,11 @@ def test_sample_rate_change_flushes_tx_and_cancels_source():
         return
 
     async def run():
-        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        done = []
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example"),
+            sip_client.SipCallbacks(on_playback_done=lambda: done.append(True)),
+        )
         client.state = sip_client.SipState.REGISTERED
         client._local_ip = "192.0.2.1"
         orig = _invite_request(
@@ -1592,13 +1596,15 @@ def test_sample_rate_change_flushes_tx_and_cancels_source():
             bytes(client.rtp._tx_buffer),
             client._tx_source_task,
             task.cancel.called,
+            done,
         )
 
-    name, buffered, source_task, cancelled = asyncio.run(run())
+    name, buffered, source_task, cancelled, done = asyncio.run(run())
     assert name == "PCMA"
     assert buffered == b""
     assert source_task is None
     assert cancelled is True
+    assert done == [True]
 
 
 def test_update_with_sdp_returns_answer():
@@ -1811,6 +1817,35 @@ def test_rtp_hold_resume_catches_up_timestamp():
     assert timestamp == 1000 + 100 * 160
     assert marked is True
     assert enabled is True
+
+
+def test_rtp_hold_clears_in_flight_dtmf():
+    async def run():
+        session = rtp_session.RtpSession()
+        session._timestamp = 8000
+        session._ts_increment = 160
+        session._dtmf_active = True
+        session._dtmf_timestamp = 1000
+        session._dtmf_duration = 80
+        session._dtmf_queue.extend("12")
+        clock = {"t": 5.0}
+        session._loop.time = lambda: clock["t"]
+        session.set_tx_enabled(False)
+        paused = (
+            session._dtmf_active,
+            list(session._dtmf_queue),
+            session._timestamp,
+        )
+        clock["t"] = 6.0
+        session.set_tx_enabled(True)
+        return paused, session._timestamp, session._dtmf_active, list(session._dtmf_queue)
+
+    paused, ts, active, queued = asyncio.run(run())
+    assert paused == (False, [], 8000)
+    # 1.0 s / 20 ms = 50 frames × 160; not rewound to the DTMF timestamp.
+    assert ts == 8000 + 50 * 160
+    assert active is False
+    assert queued == []
 
 
 def test_rtp_g722_frame_size_and_timestamp():


### PR DESCRIPTION
## Summary
- Distinguish INVITE retransmission, in-dialog re-INVITE, and a new call so hold / transfer / Asterisk `direct_media` no longer drop the session.
- Answer re-INVITE with that request's Via branch and CSeq plus an SDP answer, retarget RTP without restarting media, and stop TX on SDP hold (`a=sendonly` / `a=inactive` / `c=0.0.0.0`).
- Answer `UPDATE` with SDP when the request offered one. Existing 107 tests still pass; 6 new cases lock the roadmap acceptance criteria.

## Test plan
- [x] `python -m pytest tests/` (113 passed on Python 3.14)
- [x] `ruff check custom_components/`
- [ ] Place a FreePBX/Asterisk call, put it on hold and resume; the call should stay up
- [ ] With `direct_media=yes`, confirm audio continues after the re-INVITE that switches to peer-to-peer RTP
- [ ] Outbound call receiving re-INVITE should get 200 OK, not 486 Busy Here


Made with [Cursor](https://cursor.com)