### PR TITLE
test: add mock registrar harness and registration recovery (P0-4)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -349,7 +349,7 @@ ruff check custom_components/     # 린트
 
 ---
 
-### [ ] P0-4. mock registrar 테스트 하네스 + 등록 복구 회귀 테스트
+### [x] P0-4. mock registrar 테스트 하네스 + 등록 복구 회귀 테스트
 
 **근거** §1.3-4. "PBX/네트워크 재시작 후 자동 복구되는가"가 가장 중요한 질문인데
 정확히 여기가 테스트 공백이다. 투자 효율이 가장 높은 카드다.
@@ -381,7 +381,18 @@ ruff check custom_components/     # 린트
 - 전체 테스트 실행 시간이 현재 대비 10초 이상 늘지 않는다.
 - 하네스가 P0-1(re-INVITE)과 P0-2(latching) 테스트에도 재사용된다.
 
-**의존성** 없음. **P0-1~3과 병행 가능하고, 오히려 먼저 만들면 나머지가 쉬워진다.**
+**추가된 테스트** (`tests/test_registration.py`)
+- `test_register_401_then_success_emits_once`
+- `test_register_407_proxy_auth`
+- `test_register_423_raises_expires`
+- `test_register_unanswered_reconnects`
+- `test_register_refresh_at_half_expiration`
+- `test_register_deferred_during_call`
+- `test_register_recovers_after_pbx_restart`
+- `test_register_403_retries_without_reconnect` (현재 10초 고정 재시도; 백오프는 P2-4)
+- `test_harness_reinvite_answers_with_new_transaction` (P0-1 경로를 소켓 하네스로 재사용)
+
+P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 
 ---
 

--- a/tests/mock_pbx.py
+++ b/tests/mock_pbx.py
@@ -1,0 +1,280 @@
+"""Asyncio UDP mock SIP registrar / minimal UAS.
+
+No Home Assistant. Used by registration-recovery tests and reusable for
+in-dialog INVITE / re-INVITE flows (P0-1) over the real socket path.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import sys
+
+_SIP = os.path.join(
+    os.path.dirname(__file__), "..", "custom_components", "sip", "sip_client"
+)
+sys.path.insert(0, os.path.abspath(_SIP))
+
+import sip_auth  # noqa: E402
+import sip_message as sm  # noqa: E402
+
+_DEFAULT_SDP = (
+    "v=0\r\n"
+    "o=- 0 0 IN IP4 127.0.0.1\r\n"
+    "s=mock-pbx\r\n"
+    "c=IN IP4 127.0.0.1\r\n"
+    "t=0 0\r\n"
+    "m=audio 40000 RTP/AVP 0 8 101\r\n"
+    "a=rtpmap:0 PCMU/8000\r\n"
+    "a=rtpmap:8 PCMA/8000\r\n"
+    "a=rtpmap:101 telephone-event/8000\r\n"
+    "a=sendrecv\r\n"
+)
+
+
+def _angle_uri(value: str) -> str:
+    lt = value.find("<")
+    gt = value.find(">")
+    if lt != -1 and gt > lt:
+        return value[lt + 1 : gt]
+    return value.strip()
+
+
+def _expires(msg: sm.SipMessage) -> int:
+    raw = msg.header("Expires")
+    if not raw:
+        contact = msg.header("Contact")
+        if "expires=" not in contact.lower():
+            return 0
+        idx = contact.lower().find("expires=")
+        raw = contact[idx + 8 :].split(";")[0].split(">")[0]
+    try:
+        return int(str(raw).strip().split(";")[0].strip())
+    except (TypeError, ValueError):
+        return 0
+
+
+class _PbxProtocol(asyncio.DatagramProtocol):
+    def __init__(self, pbx: MockPbx) -> None:
+        self._pbx = pbx
+
+    def datagram_received(self, data: bytes, addr) -> None:
+        self._pbx._on_datagram(data, addr)
+
+
+class MockPbx:
+    """UDP registrar that can 401/407-challenge, 423, drop, or force a status."""
+
+    def __init__(
+        self,
+        username: str = "1001",
+        password: str = "secret",
+        realm: str = "asterisk",
+        domain: str = "pbx.example",
+    ) -> None:
+        self.username = username
+        self.password = password
+        self.realm = realm
+        self.domain = domain
+        self.require_auth = True
+        self.challenge = "www"  # "www" → 401, "proxy" → 407
+        self.min_expires = 0
+        self.drop = False
+        self.force_code: int | None = None
+        self.auto_answer_invite = True
+        self.nonce = "n" + os.urandom(8).hex()
+        self.to_tag = sm.gen_tag()
+        self.received: list[sm.SipMessage] = []
+        self.peer_addr: tuple[str, int] | None = None
+        self.client_contact = ""
+        self.host = "127.0.0.1"
+        self.port = 0
+        self._transport: asyncio.DatagramTransport | None = None
+        self._sock: socket.socket | None = None
+
+    @property
+    def registers(self) -> list[sm.SipMessage]:
+        return [m for m in self.received if m.method == "REGISTER"]
+
+    @property
+    def invites(self) -> list[sm.SipMessage]:
+        return [m for m in self.received if m.method == "INVITE"]
+
+    async def start(self, host: str = "127.0.0.1", port: int = 0) -> None:
+        loop = asyncio.get_running_loop()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        self.host, self.port = sock.getsockname()
+        self._sock = sock
+        self._transport, _ = await loop.create_datagram_endpoint(
+            lambda: _PbxProtocol(self),
+            sock=sock,
+        )
+
+    async def stop(self) -> None:
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+        self._sock = None
+
+    async def restart(self) -> None:
+        """Close and rebind the same port (PBX reboot)."""
+        port = self.port
+        host = self.host
+        await self.stop()
+        await self.start(host, port)
+
+    def send_raw(self, msg: str, addr: tuple[str, int] | None = None) -> None:
+        dest = addr or self.peer_addr
+        if self._transport is None or dest is None:
+            return
+        self._transport.sendto(msg.encode("utf-8"), dest)
+
+    def send_reinvite(
+        self,
+        *,
+        call_id: str,
+        frm: str,
+        to: str,
+        cseq: int = 2,
+        sdp: str | None = None,
+    ) -> None:
+        """Send an in-dialog re-INVITE toward the last client socket."""
+        if not self.client_contact:
+            return
+        body = sdp or _DEFAULT_SDP.replace("40000", "40002")
+        target = self.client_contact
+        msg = (
+            f"INVITE {target} SIP/2.0\r\n"
+            f"Via: SIP/2.0/UDP {self.host}:{self.port};branch={sm.gen_branch()}\r\n"
+            "Max-Forwards: 70\r\n"
+            f"From: {frm}\r\n"
+            f"To: {to}\r\n"
+            f"Call-ID: {call_id}\r\n"
+            f"CSeq: {cseq} INVITE\r\n"
+            f"Contact: <sip:mock@{self.host}:{self.port}>\r\n"
+            "Content-Type: application/sdp\r\n"
+            f"Content-Length: {len(body)}\r\n\r\n{body}"
+        )
+        self.send_raw(msg)
+
+    def _on_datagram(self, data: bytes, addr) -> None:
+        self.peer_addr = addr
+        raw = data.decode("utf-8", errors="replace")
+        msg = sm.parse_sip_message(raw)
+        self.received.append(msg)
+        if not msg.is_request:
+            return
+        if msg.method == "REGISTER":
+            self._handle_register(msg, addr)
+        elif msg.method == "INVITE":
+            self._handle_invite(msg, addr)
+        elif msg.method == "ACK":
+            return
+        elif msg.method == "BYE":
+            self.send_raw(self._response(msg, 200, "OK"), addr)
+
+    def _handle_register(self, msg: sm.SipMessage, addr) -> None:
+        contact = _angle_uri(msg.header("Contact"))
+        if contact:
+            self.client_contact = contact
+        if self.drop:
+            return
+        if self.force_code is not None:
+            extra = ""
+            if self.force_code == 423:
+                extra = f"Min-Expires: {self.min_expires or 600}\r\n"
+            self.send_raw(
+                self._response(msg, self.force_code, self._reason(self.force_code), extra),
+                addr,
+            )
+            return
+        expires = _expires(msg)
+        if self.min_expires and expires < self.min_expires:
+            extra = f"Min-Expires: {self.min_expires}\r\n"
+            self.send_raw(self._response(msg, 423, "Interval Too Brief", extra), addr)
+            return
+        if self.require_auth and not self._valid_digest(msg, "REGISTER"):
+            self.send_raw(self._challenge(msg), addr)
+            return
+        extra = f"Contact: {msg.header('Contact')}\r\nExpires: {expires or 300}\r\n"
+        self.send_raw(self._response(msg, 200, "OK", extra), addr)
+
+    def _handle_invite(self, msg: sm.SipMessage, addr) -> None:
+        if not self.auto_answer_invite:
+            return
+        extra = (
+            f"Contact: <sip:mock@{self.host}:{self.port}>\r\n"
+            "Content-Type: application/sdp\r\n"
+        )
+        self.send_raw(self._response(msg, 200, "OK", extra, _DEFAULT_SDP), addr)
+
+    def _challenge(self, msg: sm.SipMessage) -> str:
+        if self.challenge == "proxy":
+            code, reason, hdr = 407, "Proxy Authentication Required", "Proxy-Authenticate"
+        else:
+            code, reason, hdr = 401, "Unauthorized", "WWW-Authenticate"
+        extra = (
+            f'{hdr}: Digest realm="{self.realm}", nonce="{self.nonce}", '
+            'algorithm=MD5, qop="auth"\r\n'
+        )
+        return self._response(msg, code, reason, extra)
+
+    def _valid_digest(self, msg: sm.SipMessage, method: str) -> bool:
+        hdr = msg.header("Authorization") or msg.header("Proxy-Authorization")
+        if not hdr:
+            return False
+        username = sm.auth_param(hdr, "username")
+        nonce = sm.auth_param(hdr, "nonce")
+        uri = sm.auth_param(hdr, "uri")
+        response = sm.auth_param(hdr, "response")
+        qop = sm.auth_param(hdr, "qop")
+        nc = sm.auth_param(hdr, "nc")
+        cnonce = sm.auth_param(hdr, "cnonce")
+        if username != self.username or nonce != self.nonce or not uri or not response:
+            return False
+        expected = sip_auth.digest_response(
+            username,
+            self.password,
+            self.realm,
+            method,
+            uri,
+            nonce,
+            "auth" if qop else "",
+            nc,
+            cnonce,
+        )
+        return response == expected
+
+    def _response(
+        self,
+        req: sm.SipMessage,
+        code: int,
+        reason: str,
+        extra: str = "",
+        body: str = "",
+    ) -> str:
+        to = req.header("To")
+        if "tag=" not in to:
+            to += f";tag={self.to_tag}"
+        return (
+            f"SIP/2.0 {code} {reason}\r\n"
+            f"Via: {req.header('Via')}\r\n"
+            f"From: {req.header('From')}\r\n"
+            f"To: {to}\r\n"
+            f"Call-ID: {req.header('Call-ID')}\r\n"
+            f"CSeq: {req.header('CSeq')}\r\n"
+            f"{extra}"
+            f"Content-Length: {len(body)}\r\n\r\n{body}"
+        )
+
+    @staticmethod
+    def _reason(code: int) -> str:
+        return {
+            403: "Forbidden",
+            404: "Not Found",
+            423: "Interval Too Brief",
+            480: "Temporarily Unavailable",
+            486: "Busy Here",
+        }.get(code, "Error")

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,400 @@
+"""Registration recovery tests against the UDP mock registrar (P0-4).
+
+Timers are fired explicitly so the suite stays well under a second of
+wall-clock wait. The harness also covers an in-dialog re-INVITE so P0-1
+can reuse the real socket path.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from mock_pbx import MockPbx
+from test_pure import sip_client
+
+if sip_client is None:  # enum.StrEnum needs Python 3.11+
+    def _skip():
+        return True
+else:
+    def _skip():
+        return False
+
+
+def fire_register_timer(client) -> None:
+    """Cancel the pending registration timer and run it now."""
+    handle = client._register_handle
+    if handle is not None:
+        handle.cancel()
+        client._register_handle = None
+    client._register_timer()
+
+
+async def _make_client(pbx, **cfg_extra):
+    registered = []
+    failed = []
+    config = sip_client.SipConfig(
+        server="127.0.0.1",
+        port=pbx.port,
+        username=pbx.username,
+        password=pbx.password,
+        domain=pbx.domain,
+        register_expiration=cfg_extra.pop("register_expiration", 120),
+        local_rtp_port=cfg_extra.pop("local_rtp_port", 17078),
+        **cfg_extra,
+    )
+    client = sip_client.SipClient(
+        config,
+        sip_client.SipCallbacks(
+            on_registered=lambda: registered.append(True),
+            on_register_failed=failed.append,
+        ),
+    )
+    return client, registered, failed
+
+
+async def _stop(client, pbx) -> None:
+    try:
+        await client.stop()
+    finally:
+        await pbx.stop()
+
+
+def test_register_401_then_success_emits_once():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        await pbx.start()
+        client, registered, failed = await _make_client(pbx)
+        try:
+            await client.start()
+            for _ in range(20):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            authed = [m for m in pbx.registers if m.header("Authorization")]
+            return (
+                list(registered),
+                list(failed),
+                client.registered,
+                client.state,
+                len(pbx.registers),
+                len(authed),
+            )
+        finally:
+            await _stop(client, pbx)
+
+    registered, failed, ok, state, nreg, nauthed = asyncio.run(run())
+    assert registered == [True]
+    assert failed == []
+    assert ok is True
+    assert state == sip_client.SipState.REGISTERED
+    assert nreg >= 2
+    assert nauthed == 1
+
+
+def test_register_407_proxy_auth():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        pbx.challenge = "proxy"
+        await pbx.start()
+        client, registered, failed = await _make_client(pbx)
+        try:
+            await client.start()
+            for _ in range(20):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            authed = [m for m in pbx.registers if m.header("Proxy-Authorization")]
+            www = [m for m in pbx.registers if m.header("Authorization")]
+            return list(registered), list(failed), len(authed), len(www)
+        finally:
+            await _stop(client, pbx)
+
+    registered, failed, nauthed, nwww = asyncio.run(run())
+    assert registered == [True]
+    assert failed == []
+    assert nauthed == 1
+    assert nwww == 0
+
+
+def test_register_423_raises_expires():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        pbx.min_expires = 600
+        await pbx.start()
+        client, registered, failed = await _make_client(pbx, register_expiration=60)
+        try:
+            await client.start()
+            for _ in range(30):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            expires = [m.header("Expires") for m in pbx.registers]
+            return (
+                list(registered),
+                list(failed),
+                client.config.register_expiration,
+                expires,
+            )
+        finally:
+            await _stop(client, pbx)
+
+    registered, failed, exp, expires = asyncio.run(run())
+    assert registered == [True]
+    assert failed == []
+    assert exp == 600
+    assert "60" in expires
+    assert "600" in expires
+
+
+def test_register_unanswered_reconnects():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        pbx.drop = True
+        await pbx.start()
+        client, registered, failed = await _make_client(pbx)
+        reconnects = []
+        orig = client._reconnect
+
+        async def wrapped():
+            reconnects.append(True)
+            pbx.drop = False
+            await orig()
+
+        client._reconnect = wrapped
+        try:
+            await client.start()
+            await asyncio.sleep(0.05)
+            fire_register_timer(client)  # attempt 1
+            await asyncio.sleep(0.02)
+            fire_register_timer(client)  # attempt 2
+            await asyncio.sleep(0.02)
+            fire_register_timer(client)  # attempt 3 → reconnect
+            for _ in range(30):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            return list(reconnects), list(registered), client.registered
+        finally:
+            await _stop(client, pbx)
+
+    reconnects, registered, ok = asyncio.run(run())
+    assert reconnects == [True]
+    assert registered == [True]
+    assert ok is True
+
+
+def test_register_refresh_at_half_expiration():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        await pbx.start()
+        delays = []
+        client, registered, _failed = await _make_client(pbx, register_expiration=120)
+        real = client._schedule_register
+
+        def spy(seconds):
+            delays.append(seconds)
+            real(seconds)
+
+        client._schedule_register = spy
+        try:
+            await client.start()
+            for _ in range(20):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            return list(registered), delays
+        finally:
+            await _stop(client, pbx)
+
+    registered, delays = asyncio.run(run())
+    assert registered == [True]
+    # 200 OK schedules a refresh at expiration/2 (floored at 30s).
+    assert delays[-1] == 60
+
+
+def test_register_deferred_during_call():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        await pbx.start()
+        client, registered, _failed = await _make_client(pbx)
+        try:
+            await client.start()
+            for _ in range(20):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            before = len(pbx.registers)
+            client.state = sip_client.SipState.IN_CALL
+            delays = []
+            real = client._schedule_register
+
+            def spy(seconds):
+                delays.append(seconds)
+                real(3600)
+
+            client._schedule_register = spy
+            client._register_tick()
+            during = len(pbx.registers)
+            client.state = sip_client.SipState.REGISTERED
+            client._register_tick()
+            await asyncio.sleep(0.05)
+            return before, during, len(pbx.registers), delays
+        finally:
+            await _stop(client, pbx)
+
+    before, during, after, delays = asyncio.run(run())
+    assert during == before
+    assert delays[0] == 30
+    assert after > before
+
+
+def test_register_recovers_after_pbx_restart():
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        await pbx.start()
+        client, registered, _failed = await _make_client(pbx)
+        try:
+            await client.start()
+            for _ in range(20):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            first = list(registered)
+            registered.clear()
+            await pbx.stop()
+            fire_register_timer(client)  # REGISTERED refresh → REGISTERING
+            await asyncio.sleep(0.02)
+            fire_register_timer(client)  # unanswered 1
+            await asyncio.sleep(0.02)
+            fire_register_timer(client)  # unanswered 2
+            await asyncio.sleep(0.02)
+            await pbx.start(pbx.host, pbx.port)
+            fire_register_timer(client)  # unanswered 3 → reconnect
+            for _ in range(40):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            return first, list(registered), client.registered
+        finally:
+            await _stop(client, pbx)
+
+    first, recovered, ok = asyncio.run(run())
+    assert first == [True]
+    assert recovered == [True]
+    assert ok is True
+
+
+def test_register_403_retries_without_reconnect():
+    """403 currently retries at 10s without reconnect; exponential backoff is P2-4."""
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        pbx.require_auth = False
+        pbx.force_code = 403
+        await pbx.start()
+        delays = []
+        reconnects = []
+        client, registered, failed = await _make_client(pbx)
+        orig_sched = client._schedule_register
+
+        def spy(seconds):
+            delays.append(seconds)
+            orig_sched(3600)
+
+        async def no_reconnect():
+            reconnects.append(True)
+
+        client._schedule_register = spy
+        client._reconnect = no_reconnect
+        try:
+            await client.start()
+            for _ in range(20):
+                if failed or registered:
+                    break
+                await asyncio.sleep(0.02)
+            return list(registered), list(failed), delays, reconnects
+        finally:
+            await _stop(client, pbx)
+
+    registered, failed, delays, reconnects = asyncio.run(run())
+    assert registered == []
+    assert failed and failed[0].startswith("403")
+    assert delays[-1] == 10
+    assert reconnects == []
+
+
+def test_harness_reinvite_answers_with_new_transaction():
+    """Mock PBX UAS: outbound call then in-dialog re-INVITE (P0-1 reuse)."""
+    if _skip():
+        return
+
+    async def run():
+        pbx = MockPbx()
+        pbx.require_auth = False
+        await pbx.start()
+        client, registered, _failed = await _make_client(pbx)
+        try:
+            await client.start()
+            for _ in range(20):
+                if registered:
+                    break
+                await asyncio.sleep(0.02)
+            with patch.object(client, "_start_media", new_callable=AsyncMock):
+                client.call("2000")
+                for _ in range(30):
+                    if client.state == sip_client.SipState.IN_CALL:
+                        break
+                    await asyncio.sleep(0.02)
+                connected = client.state
+                call_id = client._d_call_id
+                local = client._d_local
+                remote = client._d_remote
+                sent = []
+                orig_send = client._send_raw
+
+                def capture(msg):
+                    sent.append(msg)
+                    orig_send(msg)
+
+                client._send_raw = capture
+                pbx.send_reinvite(
+                    call_id=call_id,
+                    frm=remote,
+                    to=local,
+                    cseq=2,
+                )
+                await asyncio.sleep(0.05)
+            return connected, sent, client.state
+        finally:
+            await _stop(client, pbx)
+
+    connected, sent, state = asyncio.run(run())
+    assert connected == sip_client.SipState.IN_CALL
+    assert state == sip_client.SipState.IN_CALL
+    replies = [s for s in sent if s.startswith("SIP/2.0 200 OK")]
+    assert replies
+    assert "CSeq: 2 INVITE\r\n" in replies[-1]
+    assert "Content-Type: application/sdp" in replies[-1]


### PR DESCRIPTION
## Summary
- Add `tests/mock_pbx.py`, an asyncio UDP registrar/UAS (401/407 digest, 423 Min-Expires, drop, forced status, INVITE/re-INVITE).
- Cover registration recovery: auth success once, proxy auth (#17), 423 (#20), 3× unanswered reconnect, refresh at `expiration/2`, defer during IN_CALL, PBX restart, and 403 retry without reconnect (backoff remains P2-4).
- Reuse the harness for an in-dialog re-INVITE (P0-1 path). Timers are fired explicitly so the suite stays well under the +10s budget.

## Test plan
- [x] `python -m pytest tests/` (168 passed on Python 3.14, ~5s)
- [x] `ruff check custom_components/ tests/`
- [ ] Optional: run `tests/test_registration.py` alone and confirm REGISTER 401→200 on the loopback socket


Made with [Cursor](https://cursor.com)