### PR TITLE
feat: add opt-in SIP/RTP trace with credential masking (P1-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,3 +675,12 @@ action:
 - **Registration fails**: Double-check the SIP extension credentials and host IP address. Ensure your firewall or FreePBX settings permit UDP traffic on port `5060` from the Home Assistant host.
 - **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Ensure the RTP port range (defaults starting at `7078`) is open and routed properly.
 - **FFmpeg errors**: Ensure that the `ffmpeg` system binary is installed and accessible in your Home Assistant path, as it is utilized for audio transcoding.
+- **SIP / RTP protocol trace**: Off by default. To capture signalling (INVITE / 200 OK / REGISTER) and a 5-second RTP summary without putting digest credentials in the log, add this to `configuration.yaml` and restart:
+
+  ```yaml
+  logger:
+    logs:
+      custom_components.sip.sip_client.trace: debug
+  ```
+
+  `Authorization` / `Proxy-Authorization` values (`response`, `nonce`, `cnonce`) are masked as `****`. RTP is summarised (packet counts, payload type, estimated loss, latched address), not logged packet-by-packet. Turn the logger back to `info` when you are done.

--- a/README.md
+++ b/README.md
@@ -683,4 +683,4 @@ action:
       custom_components.sip.sip_client.trace: debug
   ```
 
-  `Authorization` / `Proxy-Authorization` values (`response`, `nonce`, `cnonce`) are masked as `****`. RTP is summarised (packet counts, payload type, estimated loss, latched address), not logged packet-by-packet. Turn the logger back to `info` when you are done.
+  `Authorization` / `Proxy-Authorization` values (`response`, `nonce`, `cnonce`) are masked as `****`. RTP is summarised (packet counts, payload type, estimated loss, latched address), not logged packet-by-packet. That YAML logger is the narrow switch; the integration's **Enable debug logging** button also turns this on, because it sets `custom_components.sip` (and therefore this child logger) to DEBUG — credentials stay masked, but phone numbers and SDP will be in the log you download for an issue. Turn the logger back to `info` when you are done.

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -22,6 +22,7 @@ import struct
 from typing import Callable
 
 from . import codecs
+from . import trace
 from .codecs import Codec
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,12 +36,20 @@ _DTMF_END_PACKETS = 3
 # Asterisk strictrtp-style consecutive learn count (typical 3–5).
 _LATCH_LEARN_COUNT = 4
 _LATCH_SEQ_GAP_MAX = 64
+_TRACE_INTERVAL = 5.0
+_TRACE_LOSS_GAP_MAX = 2000
 
 
 def _rtp_seq_follows(prev: int, seq: int) -> bool:
     """True if ``seq`` is a plausible next RTP sequence number after ``prev``."""
     delta = (seq - prev) & 0xFFFF
     return 1 <= delta <= _LATCH_SEQ_GAP_MAX
+
+
+def _fmt_endpoint(addr: tuple[str, int] | None) -> str:
+    if addr is None:
+        return "-"
+    return f"{addr[0]}:{addr[1]}"
 
 
 def _dtmf_event_to_char(event: int) -> str | None:
@@ -124,6 +133,8 @@ class RtpSession:
         self.expect_rx = True
         self._last_rx_at: float | None = None
         self._media_timeout_handle: asyncio.TimerHandle | None = None
+        self._trace_handle: asyncio.TimerHandle | None = None
+        self._reset_trace_stats()
 
         # Codec-derived pacing / encode state (defaults = G.711 PCMU).
         self._codec: Codec = codecs.DEFAULT
@@ -280,10 +291,13 @@ class RtpSession:
                 "will only work if the device sends it via SIP INFO"
             )
         self._note_rx()
+        self._reset_trace_stats()
+        self._arm_trace()
         return True
 
     async def stop(self) -> None:
         self._cancel_media_timeout()
+        self._cancel_trace()
         self._last_rx_at = None
         if self._sender_task is not None:
             self._sender_task.cancel()
@@ -348,6 +362,7 @@ class RtpSession:
     def _send(self, packet: bytes) -> None:
         if self._transport is not None and self._remote is not None:
             self._transport.sendto(packet, self._remote)
+            self._note_trace_tx(packet)
 
     def _send_audio_packet(self, frame: bytes) -> None:
         header = self._rtp_header(self._first_packet, self.payload_type, self._timestamp)
@@ -497,6 +512,61 @@ class RtpSession:
         except Exception:  # noqa: BLE001
             _LOGGER.exception("on_media_timeout raised")
 
+    def _reset_trace_stats(self) -> None:
+        self._trace_rx = 0
+        self._trace_tx = 0
+        self._trace_rx_pt: int | None = None
+        self._trace_tx_pt: int | None = None
+        self._trace_lost = 0
+        self._trace_rx_seq: int | None = None
+
+    def _arm_trace(self) -> None:
+        self._cancel_trace()
+        self._trace_handle = self._loop.call_later(
+            _TRACE_INTERVAL, self._trace_tick
+        )
+
+    def _cancel_trace(self) -> None:
+        if self._trace_handle is not None:
+            self._trace_handle.cancel()
+            self._trace_handle = None
+
+    def _trace_tick(self) -> None:
+        self._trace_handle = None
+        self._emit_rtp_trace()
+        if self._transport is not None:
+            self._arm_trace()
+
+    def _emit_rtp_trace(self) -> None:
+        if not trace.enabled():
+            return
+        trace.log_rtp(
+            "RTP %ss: rx=%s tx=%s pt=%s/%s lost~%s latch=%s sdp=%s",
+            int(_TRACE_INTERVAL),
+            self._trace_rx,
+            self._trace_tx,
+            "-" if self._trace_rx_pt is None else self._trace_rx_pt,
+            "-" if self._trace_tx_pt is None else self._trace_tx_pt,
+            self._trace_lost,
+            _fmt_endpoint(self._latched_remote),
+            _fmt_endpoint(self._sdp_remote),
+        )
+        self._reset_trace_stats()
+
+    def _note_trace_tx(self, packet: bytes) -> None:
+        self._trace_tx += 1
+        if len(packet) >= 2:
+            self._trace_tx_pt = packet[1] & 0x7F
+
+    def _note_trace_rx(self, seq: int, pt: int) -> None:
+        self._trace_rx += 1
+        self._trace_rx_pt = pt
+        if self._trace_rx_seq is not None:
+            delta = (seq - self._trace_rx_seq) & 0xFFFF
+            if 1 < delta <= _TRACE_LOSS_GAP_MAX:
+                self._trace_lost += delta - 1
+        self._trace_rx_seq = seq
+
     # -- RX -------------------------------------------------------------
     def _receive(self, data: bytes, addr: tuple[str, int] | None = None) -> None:
         try:
@@ -521,6 +591,7 @@ class RtpSession:
             return
         seq = int.from_bytes(data[2:4], "big")
         ssrc = int.from_bytes(data[8:12], "big")
+        self._note_trace_rx(seq, pt)
 
         payload_len = len(data) - header_len
         is_dtmf = pt == self.dtmf_pt if self.dtmf_pt >= 0 else False

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -17,6 +17,7 @@ from typing import Callable
 
 from . import codecs
 from . import sip_message as sm
+from . import trace
 from .audio import AudioSink, AudioSource, NullSink
 from .rtp_session import RtpSession
 from .sip_auth import digest_response
@@ -350,6 +351,7 @@ class SipClient:
     def _send_raw(self, msg: str) -> None:
         if self._transport is None:
             return
+        trace.log_sip("TX", msg)
         self._transport.sendto(msg.encode("utf-8"))
 
 
@@ -1390,6 +1392,7 @@ class SipClient:
         # take down the UDP listener or the integration.
         try:
             raw = data.decode("utf-8", errors="replace")
+            trace.log_sip("RX", raw)
 
             m = sm.parse_sip_message(raw)
             if m.is_request:

--- a/custom_components/sip/sip_client/trace.py
+++ b/custom_components/sip/sip_client/trace.py
@@ -1,0 +1,83 @@
+"""Opt-in SIP/RTP protocol trace with credential masking.
+
+Enable from Home Assistant ``configuration.yaml``:
+
+    logger:
+      logs:
+        custom_components.sip.sip_client.trace: debug
+
+Off by default. Callers must go through :func:`log_sip` / :func:`log_rtp`
+(or check :func:`enabled`) before building log strings so masking and
+format work are skipped when the logger is not at DEBUG.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+_LOGGER = logging.getLogger(__name__)
+
+REDACTED = "****"
+
+# Digest fields that are the response hash or the challenge material used
+# to compute it. Applied only on Authorization / Proxy-Authorization lines.
+_SECRET_PARAM = re.compile(
+    r"\b(response|nonce|cnonce|password)\s*=\s*"
+    r'(?:"[^"]*"|\'[^\']*\'|[^\s,]+)',
+    re.IGNORECASE,
+)
+
+_BASIC_AUTH = re.compile(
+    r"^((?:Proxy-)?Authorization:\s*Basic)\s+\S+",
+    re.IGNORECASE,
+)
+
+
+def enabled() -> bool:
+    """True when the trace logger will emit DEBUG records."""
+    return _LOGGER.isEnabledFor(logging.DEBUG)
+
+
+def _redact_param(match: re.Match[str]) -> str:
+    return f'{match.group(1)}="{REDACTED}"'
+
+
+def mask_sip(msg: str) -> str:
+    """Return a SIP message with digest secrets replaced by ``****``."""
+    parts: list[str] = []
+    for line in msg.splitlines(keepends=True):
+        if line.endswith("\r\n"):
+            body, ending = line[:-2], "\r\n"
+        elif line.endswith("\n"):
+            body, ending = line[:-1], "\n"
+        elif line.endswith("\r"):
+            body, ending = line[:-1], "\r"
+        else:
+            body, ending = line, ""
+        stripped = body.lstrip(" \t")
+        lead = body[: len(body) - len(stripped)]
+        lower = stripped.lower()
+        if lower.startswith("authorization:") or lower.startswith(
+            "proxy-authorization:"
+        ):
+            basic = _BASIC_AUTH.sub(rf"\1 {REDACTED}", stripped, count=1)
+            if basic != stripped:
+                stripped = basic
+            else:
+                stripped = _SECRET_PARAM.sub(_redact_param, stripped)
+        parts.append(lead + stripped + ending)
+    return "".join(parts)
+
+
+def log_sip(direction: str, msg: str) -> None:
+    """Log a SIP datagram at DEBUG after masking, or no-op if disabled."""
+    if not enabled():
+        return
+    _LOGGER.debug("%s\n%s", direction, mask_sip(msg))
+
+
+def log_rtp(fmt: str, *args) -> None:
+    """Log an RTP summary line at DEBUG, or no-op if disabled."""
+    if not enabled():
+        return
+    _LOGGER.debug(fmt, *args)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ DTMF 인식 실패, choppy live TTS(#45, 열림). **전부 안정성·PBX 호환
 
 ### 1.2 잘 되어 있는 것 (되돌리지 말 것)
 
-- **SIP core와 HA layer 분리 완료.** `custom_components/sip/sip_client/` 8개 모듈에
+- **SIP core와 HA layer 분리 완료.** `custom_components/sip/sip_client/` 9개 모듈에
   `homeassistant` import가 0건이다. 테스트가 HA 없이 코어를 로드한다(`tests/conftest.py`).
   추가 계층 분리 리팩터링은 순손실이다.
 - **G.722 clock/sample rate 분리가 정확하다.** `sip_client/codecs.py`에서 RTP clock 8000,
@@ -47,7 +47,9 @@ DTMF 인식 실패, choppy live TTS(#45, 열림). **전부 안정성·PBX 호환
 - **SIP 라우팅/트랜잭션 처리 상당 부분이 이미 견고하다.** Record-Route wire order 보존,
   strict/loose router 분기, CANCEL과 2xx 경합, forked 2xx의 ACK+BYE 정리,
   401 재인증 후 INVITE CSeq 유지, UDP INVITE 재전송 T1 백오프. 모두 테스트로 잠겨 있다.
-- **비밀번호 로그 노출 경로가 없다.** 원시 SIP 메시지를 로깅하는 코드가 아예 없다.
+- **비밀번호는 기본 로그에 노출되지 않는다.** 원시 SIP 메시지는 opt-in
+  `custom_components.sip.sip_client.trace` DEBUG에서만 남고, digest
+  `response`/`nonce`/`cnonce`는 마스킹된다 (P1-1).
 - **Assist 세션 상태 관리가 견고하다.** `_tts_epoch`로 stale TTS 무효화, tone/tts 대기
   이벤트 분리, silent/error streak 구분. 관련 테스트 40개 이상.
 
@@ -400,12 +402,13 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 
 이슈 대응 비용을 직접 줄이는 단계. P0 수정의 효과를 사용자 환경에서 확인할 수단도 된다.
 
-### [ ] P1-1. opt-in SIP/RTP 트레이스 (크리덴셜 마스킹)
+### [x] P1-1. opt-in SIP/RTP 트레이스 (크리덴셜 마스킹)
 
 **근거** §1.3-5. 현재 원시 메시지 로깅이 전혀 없어 비밀번호는 안전하지만
 원격 진단이 불가능하다. 필요한 것은 "트레이스 없음"이 아니라 "마스킹된 트레이스"다.
 
-**대상** `sip_client.py` `_send_raw`(:311), `_on_packet`(:1162), `rtp_session.py`
+**대상** `sip_client.py` `_send_raw`, `_on_packet`, `rtp_session.py`,
+새 파일 `sip_client/trace.py`
 
 **작업**
 1. `sip.trace` 전용 로거를 만들고 DEBUG 레벨에서만 송수신 SIP 메시지를 남긴다.
@@ -420,6 +423,23 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 - 트레이스 활성 시 INVITE/200 OK/REGISTER 왕복이 로그에 남는다.
 - `Authorization` 헤더가 포함된 메시지에서 `response=` 값이 마스킹된다(테스트).
 - 트레이스 비활성이 기본이고, 비활성 시 문자열 포맷 비용이 발생하지 않는다.
+
+**추가된 테스트** (`tests/test_trace.py`)
+- `test_trace_disabled_by_default`
+- `test_mask_sip_authorization_response`
+- `test_mask_sip_nonce_and_cnonce`
+- `test_mask_sip_proxy_authorization`
+- `test_mask_sip_unquoted_digest_params`
+- `test_mask_sip_leaves_www_authenticate`
+- `test_mask_sip_basic_authorization`
+- `test_mask_sip_password_param`
+- `test_log_sip_skips_masking_when_disabled`
+- `test_log_sip_masks_before_debug`
+- `test_sip_send_and_recv_traced_when_enabled`
+- `test_sip_send_raw_does_not_format_when_disabled`
+- `test_rtp_trace_summary_counts_loss_and_latch`
+- `test_rtp_trace_summary_silent_when_disabled`
+- `test_rtp_trace_timer_cancelled_on_stop`
 
 ---
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -43,6 +43,7 @@ def _load_pkg_module(name):
 
 g722 = _load_pkg_module("g722")
 codecs = _load_pkg_module("codecs")
+trace = _load_pkg_module("trace")
 rtp_session = _load_pkg_module("rtp_session")
 audio = _load_pkg_module("audio")
 try:

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,276 @@
+"""Opt-in SIP/RTP trace: credential masking and no-cost-when-disabled (P1-1)."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from test_pure import rtp_session, sip_client, trace
+
+_DIGEST = (
+    "REGISTER sip:pbx.example SIP/2.0\r\n"
+    "Via: SIP/2.0/UDP 192.0.2.10:5060;branch=z9hG4bK1\r\n"
+    "From: <sip:100@pbx.example>;tag=local\r\n"
+    "To: <sip:100@pbx.example>\r\n"
+    "Call-ID: reg@host\r\n"
+    "CSeq: 2 REGISTER\r\n"
+    'Authorization: Digest username="100", realm="asterisk", '
+    'nonce="abc123nonce", uri="sip:pbx.example", '
+    'response="6629fae49393a05397450978507c4ef1", algorithm=MD5, '
+    'qop=auth, nc=00000001, cnonce="0a4f113b"\r\n'
+    "Content-Length: 0\r\n"
+    "\r\n"
+)
+
+_INVITE = (
+    "INVITE sip:200@pbx.example SIP/2.0\r\n"
+    "Via: SIP/2.0/UDP 192.0.2.10:5060;branch=z9hG4bKinv\r\n"
+    "From: <sip:100@pbx.example>;tag=out\r\n"
+    "To: <sip:200@pbx.example>\r\n"
+    "Call-ID: call@host\r\n"
+    "CSeq: 1 INVITE\r\n"
+    "Content-Type: application/sdp\r\n"
+    "Content-Length: 0\r\n"
+    "\r\n"
+)
+
+_OK_REGISTER = (
+    "SIP/2.0 200 OK\r\n"
+    "Via: SIP/2.0/UDP 192.0.2.10:5060;branch=z9hG4bK1\r\n"
+    "From: <sip:100@pbx.example>;tag=local\r\n"
+    "To: <sip:100@pbx.example>;tag=pbx\r\n"
+    "Call-ID: reg@host\r\n"
+    "CSeq: 1 REGISTER\r\n"
+    "Content-Length: 0\r\n"
+    "\r\n"
+)
+
+_OK_INVITE = (
+    "SIP/2.0 200 OK\r\n"
+    "Via: SIP/2.0/UDP 192.0.2.10:5060;branch=z9hG4bKinv\r\n"
+    "From: <sip:100@pbx.example>;tag=out\r\n"
+    "To: <sip:200@pbx.example>;tag=pbx\r\n"
+    "Call-ID: call@host\r\n"
+    "CSeq: 1 INVITE\r\n"
+    "Content-Length: 0\r\n"
+    "\r\n"
+)
+
+
+def test_trace_disabled_by_default():
+    assert not trace.enabled()
+    assert not trace._LOGGER.isEnabledFor(logging.DEBUG)
+
+
+def test_mask_sip_authorization_response():
+    secret = "6629fae49393a05397450978507c4ef1"
+    out = trace.mask_sip(_DIGEST)
+    assert secret not in out
+    assert 'response="****"' in out
+    assert "username=\"100\"" in out
+    assert "REGISTER sip:pbx.example" in out
+
+
+def test_mask_sip_nonce_and_cnonce():
+    out = trace.mask_sip(_DIGEST)
+    assert "abc123nonce" not in out
+    assert "0a4f113b" not in out
+    assert 'nonce="****"' in out
+    assert 'cnonce="****"' in out
+
+
+def test_mask_sip_proxy_authorization():
+    secret = "aabbccddeeff00112233445566778899"
+    msg = (
+        "INVITE sip:200@pbx SIP/2.0\r\n"
+        f'Proxy-Authorization: Digest username="100", nonce="n1", '
+        f'response="{secret}", cnonce="cn1"\r\n'
+        "\r\n"
+    )
+    out = trace.mask_sip(msg)
+    assert secret not in out
+    assert "n1" not in out
+    assert "cn1" not in out
+    assert 'response="****"' in out
+    assert "Proxy-Authorization:" in out
+
+
+def test_mask_sip_unquoted_digest_params():
+    msg = (
+        "Authorization: Digest username=100, nonce=plainnonce, "
+        "response=deadbeefcafebabe, cnonce=plaincnonce\r\n"
+    )
+    out = trace.mask_sip(msg)
+    assert "deadbeefcafebabe" not in out
+    assert "plainnonce" not in out
+    assert "plaincnonce" not in out
+    assert 'response="****"' in out
+
+
+def test_mask_sip_leaves_www_authenticate():
+    nonce = "server-challenge-nonce"
+    msg = (
+        "SIP/2.0 401 Unauthorized\r\n"
+        f'WWW-Authenticate: Digest realm="asterisk", nonce="{nonce}"\r\n'
+        "\r\n"
+    )
+    out = trace.mask_sip(msg)
+    assert nonce in out
+    assert "WWW-Authenticate:" in out
+
+
+def test_mask_sip_basic_authorization():
+    msg = "Authorization: Basic dXNlcjpwYXNzd29yZA==\r\n"
+    out = trace.mask_sip(msg)
+    assert "dXNlcjpwYXNzd29yZA==" not in out
+    assert "Authorization: Basic ****" in out
+
+
+def test_mask_sip_password_param():
+    msg = 'Authorization: Digest username="u", password="s3cret", response="ab"\r\n'
+    out = trace.mask_sip(msg)
+    assert "s3cret" not in out
+    assert 'password="****"' in out
+
+
+def test_log_sip_skips_masking_when_disabled():
+    with patch.object(trace, "mask_sip", wraps=trace.mask_sip) as mask:
+        with patch.object(trace._LOGGER, "debug") as debug:
+            trace.log_sip("TX", _DIGEST)
+    assert mask.call_count == 0
+    assert debug.call_count == 0
+
+
+def test_log_sip_masks_before_debug():
+    captured = []
+
+    def fake_debug(fmt, *args):
+        captured.append(fmt % args if args else fmt)
+
+    with patch.object(trace._LOGGER, "isEnabledFor", return_value=True):
+        with patch.object(trace._LOGGER, "debug", side_effect=fake_debug):
+            trace.log_sip("TX", _DIGEST)
+    text = "\n".join(captured)
+    assert text.startswith("TX\n")
+    assert "6629fae49393a05397450978507c4ef1" not in text
+    assert "REGISTER" in text
+
+
+def test_sip_send_and_recv_traced_when_enabled():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._transport = MagicMock()
+        captured = []
+
+        def fake_debug(fmt, *args):
+            captured.append(fmt % args if args else fmt)
+
+        with patch.object(trace._LOGGER, "isEnabledFor", return_value=True):
+            with patch.object(trace._LOGGER, "debug", side_effect=fake_debug):
+                client._send_raw(_DIGEST)
+                client._send_raw(_INVITE)
+                client._on_packet(_OK_REGISTER.encode("utf-8"))
+                client._on_packet(_OK_INVITE.encode("utf-8"))
+        return captured, client._transport.sendto.call_count
+
+    logs, sent = asyncio.run(run())
+    text = "\n".join(logs)
+    assert sent == 2
+    assert "TX\nREGISTER" in text
+    assert "TX\nINVITE" in text
+    assert "RX\nSIP/2.0 200 OK" in text
+    assert "CSeq: 1 REGISTER" in text
+    assert "CSeq: 1 INVITE" in text
+    assert "6629fae49393a05397450978507c4ef1" not in text
+    assert 'response="****"' in text
+
+
+def test_sip_send_raw_does_not_format_when_disabled():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._transport = MagicMock()
+        with patch.object(trace, "mask_sip", wraps=trace.mask_sip) as mask:
+            with patch.object(trace._LOGGER, "debug") as debug:
+                client._send_raw(_DIGEST)
+                client._on_packet(_OK_REGISTER.encode("utf-8"))
+        return mask.call_count, debug.call_count, client._transport.sendto.call_count
+
+    masks, debugs, sent = asyncio.run(run())
+    assert sent == 1
+    assert masks == 0
+    assert debugs == 0
+
+
+def test_rtp_trace_summary_counts_loss_and_latch():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.set_remote("192.168.1.10", 10000)
+        session._transport = MagicMock()
+        pkt = bytes([0x80, 0]) + struct.pack("!HII", 1, 100, 0x1234) + b"\xff" * 160
+        session._send(pkt)
+        for seq in (1, 2, 4, 5):
+            session._receive_impl(
+                bytes([0x80, 0]) + struct.pack("!HII", seq, 100, 0x1234) + b"\xff" * 160,
+                ("203.0.113.8", 20000),
+            )
+        captured = []
+
+        def fake_debug(fmt, *args):
+            captured.append(fmt % args if args else fmt)
+
+        with patch.object(trace._LOGGER, "isEnabledFor", return_value=True):
+            with patch.object(trace._LOGGER, "debug", side_effect=fake_debug):
+                session._emit_rtp_trace()
+        return captured, session._trace_rx, session.latched_remote
+
+    logs, after_reset, latched = asyncio.run(run())
+    assert len(logs) == 1
+    line = logs[0]
+    assert "rx=4" in line
+    assert "tx=1" in line
+    assert "lost~1" in line
+    assert "latch=203.0.113.8:20000" in line
+    assert "sdp=192.168.1.10:10000" in line
+    assert after_reset == 0
+    assert latched == ("203.0.113.8", 20000)
+
+
+def test_rtp_trace_summary_silent_when_disabled():
+    async def run():
+        session = rtp_session.RtpSession()
+        session._transport = MagicMock()
+        session._remote = ("192.0.2.1", 5004)
+        session._send(b"\x80\x00" + b"\x00" * 10)
+        with patch.object(trace._LOGGER, "debug") as debug:
+            session._emit_rtp_trace()
+        return debug.call_count, session._trace_tx
+
+    debugs, tx = asyncio.run(run())
+    assert debugs == 0
+    assert tx == 1
+
+
+def test_rtp_trace_timer_cancelled_on_stop():
+    async def run():
+        session = rtp_session.RtpSession()
+        transport = MagicMock()
+        with patch.object(
+            session._loop,
+            "create_datagram_endpoint",
+            new=AsyncMock(return_value=(transport, MagicMock())),
+        ):
+            assert await session.start(4000)
+        armed = session._trace_handle is not None
+        await session.stop()
+        return armed, session._trace_handle
+
+    armed, after = asyncio.run(run())
+    assert armed is True
+    assert after is None


### PR DESCRIPTION
## Summary
- Add `custom_components.sip.sip_client.trace` (DEBUG only). SIP TX/RX is logged after masking `Authorization` / `Proxy-Authorization` `response`/`nonce`/`cnonce` (and Basic / `password=`).
- RTP is not logged packet-by-packet; a 5-second summary records rx/tx counts, PT, estimated loss, and latch vs SDP addresses.
- Trace is off by default: `mask_sip` / string formatting run only when the logger is at DEBUG. README troubleshooting documents how to enable it.

## Test plan
- [x] `python -m pytest tests/` (183 passed on Python 3.14, ~5s)
- [x] `ruff check custom_components/ tests/`
- [ ] Optional: set `custom_components.sip.sip_client.trace: debug` in HA, REGISTER, and confirm `response="****"` in the log


Made with [Cursor](https://cursor.com)