### PR TITLE
feat: add config-entry diagnostics for SIP/RTP faults (P1-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ action:
 ## Troubleshooting
 
 - **Registration fails**: Double-check the SIP extension credentials and host IP address. Ensure your firewall or FreePBX settings permit UDP traffic on port `5060` from the Home Assistant host.
-- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Ensure the RTP port range (defaults starting at `7078`) is open and routed properly.
+- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Ensure the RTP port range (defaults starting at `7078`) is open and routed properly. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** — `sip.rtp.audio_path` is `no_rx` / `no_tx` / `bidirectional`, `sip.codec.mismatch` flags an offer we cannot negotiate, and `sip.registration.last_failure` shows why REGISTER failed. Passwords are redacted; phone numbers are masked.
 - **FFmpeg errors**: Ensure that the `ffmpeg` system binary is installed and accessible in your Home Assistant path, as it is utilized for audio transcoding.
 - **SIP / RTP protocol trace**: Off by default. To capture signalling (INVITE / 200 OK / REGISTER) and a 5-second RTP summary without putting digest credentials in the log, add this to `configuration.yaml` and restart:
 

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -193,6 +193,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "call_connect_time": None,
         "call_direction": None,
         "call_status": "missed",
+        "last_register_failed": None,
+        "last_registered_at": None,
         "contacts": contacts,
         "call_number": "",
     }
@@ -232,8 +234,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def on_registered() -> None:
         LOGGER.info("[%s] SIP Client successfully registered", sip_config.username)
         entry.runtime_data["registered"] = True
+        entry.runtime_data["last_register_failed"] = None
+        entry.runtime_data["last_registered_at"] = time.time()
         async_dispatcher_send(hass, f"{DOMAIN}_state_update_{entry.entry_id}")
         fire_sip_event(EVENT_SIP_REGISTERED)
+
+    @callback
+    def on_register_failed(reason: str) -> None:
+        LOGGER.warning("[%s] SIP registration failed: %s", sip_config.username, reason)
+        entry.runtime_data["registered"] = False
+        entry.runtime_data["last_register_failed"] = reason
+        async_dispatcher_send(hass, f"{DOMAIN}_state_update_{entry.entry_id}")
 
     @callback
     def on_incoming_call(caller: str) -> None:
@@ -308,6 +319,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "direction": direction,
                 "duration": duration,
                 "status": status,
+                "reason": reason,
             }
 
             history = entry.runtime_data.setdefault("call_history", [])
@@ -369,6 +381,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     callbacks = SipCallbacks(
         on_state_change=on_state_change,
         on_registered=on_registered,
+        on_register_failed=on_register_failed,
         on_incoming_call=on_incoming_call,
         on_call_connected=on_call_connected,
         on_call_ended=on_call_ended,

--- a/custom_components/sip/diagnostics.py
+++ b/custom_components/sip/diagnostics.py
@@ -1,0 +1,85 @@
+"""Config-entry diagnostics for the SIP Client integration.
+
+Download from Settings → Devices & Services → SIP Client → ⋮ → Download
+diagnostics. The payload is meant to distinguish registration failure, codec
+mismatch, and one-way audio without exposing passwords.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_AUTH_USERNAME, CONF_PASSWORD
+
+TO_REDACT = {CONF_PASSWORD, "password", CONF_AUTH_USERNAME}
+
+_KEEP_DIGITS = 2
+
+
+def mask_number(number: str | None) -> str | None:
+    """Mask a phone number / SIP user, keeping the last two digits."""
+    if not number:
+        return number
+    digits = sum(1 for c in number if c.isdigit())
+    if digits == 0:
+        return "*" * len(number)
+    seen = 0
+    out: list[str] = []
+    for char in number:
+        if char.isdigit():
+            seen += 1
+            out.append(char if seen > digits - _KEEP_DIGITS else "*")
+        else:
+            out.append(char)
+    return "".join(out)
+
+
+def _mask_history_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    masked = dict(entry)
+    if "number" in masked:
+        masked["number"] = mask_number(masked.get("number"))
+    return masked
+
+
+def collect_diagnostics(
+    config: dict[str, Any],
+    runtime: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the diagnostics payload (before HA credential redaction)."""
+    client = runtime.get("client")
+    sip = client.diagnostics_snapshot() if client is not None else {}
+    call = sip.get("call")
+    if isinstance(call, dict) and call.get("last_caller"):
+        sip = {
+            **sip,
+            "call": {**call, "last_caller": mask_number(call["last_caller"])},
+        }
+    history = [_mask_history_entry(item) for item in runtime.get("call_history", [])]
+    start = runtime.get("call_start_time")
+    connect = runtime.get("call_connect_time")
+    current = {
+        "direction": runtime.get("call_direction"),
+        "status": runtime.get("call_status"),
+        "start_time": start,
+        "connect_time": connect,
+        "number": mask_number(runtime.get("call_number") or None),
+    }
+    return {
+        "config": dict(config),
+        "sip": sip,
+        "current_call": current,
+        "call_history": history,
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    del hass  # required by the HA diagnostics platform signature
+    runtime = entry.runtime_data if isinstance(entry.runtime_data, dict) else {}
+    payload = collect_diagnostics(dict(entry.data), runtime)
+    return async_redact_data(payload, TO_REDACT)

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -280,8 +280,7 @@ class RtpSession:
         self._reset_latch()
         # Fresh codec state for this call (important for stateful codecs).
         self.set_codec(self._codec)
-        self.bytes_received = 0
-        self.bytes_sent = 0
+        self.reset_byte_counters()
         self._sender_task = self._loop.create_task(self._sender())
         _LOGGER.info(
             "RTP started on port %s (pt=%s, dtmf_pt=%s)",
@@ -316,6 +315,12 @@ class RtpSession:
         self._tx_buffer.clear()
         self._clear_dtmf_tx()
         self._rx_dtmf_timestamp = -1
+        self.reset_byte_counters()
+
+    def reset_byte_counters(self) -> None:
+        """Drop TX/RX PCM totals so a new dialog cannot inherit the last call."""
+        self.bytes_received = 0
+        self.bytes_sent = 0
 
     # -- TX -------------------------------------------------------------
     def push_tx_audio(self, pcm_le: bytes) -> None:

--- a/custom_components/sip/sip_client/rtp_session.py
+++ b/custom_components/sip/sip_client/rtp_session.py
@@ -134,6 +134,8 @@ class RtpSession:
         self._last_rx_at: float | None = None
         self._media_timeout_handle: asyncio.TimerHandle | None = None
         self._trace_handle: asyncio.TimerHandle | None = None
+        self.bytes_received = 0
+        self.bytes_sent = 0
         self._reset_trace_stats()
 
         # Codec-derived pacing / encode state (defaults = G.711 PCMU).
@@ -278,6 +280,8 @@ class RtpSession:
         self._reset_latch()
         # Fresh codec state for this call (important for stateful codecs).
         self.set_codec(self._codec)
+        self.bytes_received = 0
+        self.bytes_sent = 0
         self._sender_task = self._loop.create_task(self._sender())
         _LOGGER.info(
             "RTP started on port %s (pt=%s, dtmf_pt=%s)",
@@ -367,6 +371,8 @@ class RtpSession:
     def _send_audio_packet(self, frame: bytes) -> None:
         header = self._rtp_header(self._first_packet, self.payload_type, self._timestamp)
         self._send(header + self._encode(frame))
+        if self._transport is not None and self._remote is not None:
+            self.bytes_sent += len(frame)
         self._seq += 1
         self._timestamp += self._ts_increment
         self._first_packet = False
@@ -630,5 +636,7 @@ class RtpSession:
         if decode is None:
             return
         self._maybe_latch(addr, seq, ssrc)
+        pcm = decode(data[header_len:])
+        self.bytes_received += len(pcm)
         if self.on_audio is not None:
-            self.on_audio(decode(data[header_len:]))
+            self.on_audio(pcm)

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -159,6 +159,45 @@ def _answer_direction(sdp: sm.SdpInfo) -> str:
     return "sendrecv"
 
 
+def _offered_codec_names(sdp: sm.SdpInfo) -> list[str]:
+    named = {"G722": sdp.g722_pt, "PCMU": sdp.pcmu_pt, "PCMA": sdp.pcma_pt}
+    names: list[str] = []
+    for codec in codecs.SUPPORTED:
+        if named[codec.name] >= 0 or codec.payload_type in sdp.offered_pts:
+            names.append(codec.name)
+    return names
+
+
+def _codec_mismatch(
+    remote_names: list[str], remote_pts: list[int], dtmf_pt: int
+) -> bool:
+    """True when the remote offer has audio we cannot negotiate."""
+    supported = {c.name for c in codecs.SUPPORTED}
+    if remote_names:
+        return supported.isdisjoint(remote_names)
+    audio_pts = {pt for pt in remote_pts if pt != dtmf_pt and pt != 13}
+    if not audio_pts:
+        return False
+    known = {c.payload_type for c in codecs.SUPPORTED}
+    return audio_pts.isdisjoint(known)
+
+
+def _audio_path(rx: int, tx: int) -> str:
+    if rx > 0 and tx > 0:
+        return "bidirectional"
+    if tx > 0 and rx == 0:
+        return "no_rx"
+    if rx > 0 and tx == 0:
+        return "no_tx"
+    return "none"
+
+
+def _fmt_diag_endpoint(addr: tuple[str, int] | None) -> str | None:
+    if not addr:
+        return None
+    return f"{addr[0]}:{addr[1]}"
+
+
 class _SipProtocol(asyncio.DatagramProtocol):
     def __init__(self, on_packet: Callable[[bytes], None]) -> None:
         self._on_packet = on_packet
@@ -186,6 +225,13 @@ class SipClient:
         self.state = SipState.IDLE
         self.registered = False
         self.last_caller = ""
+        self.last_registered_at: float | None = None
+        self.last_register_failed: str | None = None
+        self.last_call_reason: str | None = None
+        self.last_call_bytes_rx = 0
+        self.last_call_bytes_tx = 0
+        self._remote_offered_pts: list[int] = []
+        self._remote_offered_names: list[str] = []
         self._register_handle: asyncio.TimerHandle | None = None
         self._reg_attempts = 0
 
@@ -259,13 +305,63 @@ class SipClient:
     def set_sink(self, sink: AudioSink) -> None:
         self.sink = sink
 
+    def diagnostics_snapshot(self) -> dict:
+        """Runtime SIP/RTP state for the HA diagnostics download (no secrets)."""
+        if self.rtp.running:
+            rx, tx = self.rtp.bytes_received, self.rtp.bytes_sent
+        else:
+            rx, tx = self.last_call_bytes_rx, self.last_call_bytes_tx
+        sdp = self.rtp.sdp_remote
+        if sdp is None and self._remote_rtp_ip:
+            sdp = (self._remote_rtp_ip, self._remote_rtp_port)
+        return {
+            "state": str(self.state),
+            "registration": {
+                "registered": self.registered,
+                "last_registered_at": self.last_registered_at,
+                "last_failure": self.last_register_failed,
+            },
+            "codec": {
+                "negotiated": self._codec.name,
+                "payload_type": self._codec.payload_type,
+                "sample_rate": self._codec.sample_rate,
+                "telephone_event_pt": self._remote_dtmf_pt,
+                "local_supported": [c.name for c in codecs.SUPPORTED],
+                "remote_offered": list(self._remote_offered_names),
+                "remote_offered_pts": list(self._remote_offered_pts),
+                "mismatch": _codec_mismatch(
+                    self._remote_offered_names,
+                    self._remote_offered_pts,
+                    self._remote_dtmf_pt,
+                ),
+            },
+            "rtp": {
+                "sdp_remote": _fmt_diag_endpoint(sdp),
+                "latched_remote": _fmt_diag_endpoint(self.rtp.latched_remote),
+                "bytes_received": rx,
+                "bytes_sent": tx,
+                "audio_path": _audio_path(rx, tx),
+                "expect_rx": self.rtp.expect_rx,
+                "tx_enabled": self.rtp.tx_enabled,
+                "running": self.rtp.running,
+            },
+            "call": {
+                "in_call": self.in_call,
+                "outbound": self._outbound,
+                "local_direction": self._local_direction,
+                "on_hold": self._on_hold,
+                "last_end_reason": self.last_call_reason,
+                "last_caller": self.last_caller,
+            },
+        }
+
     # -- lifecycle ------------------------------------------------------
     async def start(self) -> None:
         self._closing = False
         if await self._open_socket():
             self._do_register()
         else:
-            self._emit("on_register_failed", "Connection failed")
+            self._register_failed("Connection failed")
             self._schedule_register(10)  # keep retrying; _register_timer recovers
 
     async def stop(self) -> None:
@@ -494,15 +590,16 @@ class SipClient:
             )
             self.registered = False
             self._reg_attempts = 0
-            self._emit(
-                "on_register_failed",
-                f"423 Interval Too Brief (Min-Expires={min_expires})",
+            self._register_failed(
+                f"423 Interval Too Brief (Min-Expires={min_expires})"
             )
             self._schedule_register(10)
             return
         if 200 <= m.status_code < 300:
             was = self.registered
             self.registered = True
+            self.last_register_failed = None
+            self.last_registered_at = time.time()
             self._reg_attempts = 0
             self._set_state(SipState.REGISTERED)
             self._schedule_register(max(self.config.register_expiration // 2, 30))
@@ -516,8 +613,12 @@ class SipClient:
         self.registered = False
         # The server responded, so the socket is alive: gentle retry, no reconnect.
         self._reg_attempts = 0
-        self._emit("on_register_failed", f"{m.status_code} {m.reason}")
+        self._register_failed(f"{m.status_code} {m.reason}")
         self._schedule_register(10)
+
+    def _register_failed(self, reason: str) -> None:
+        self.last_register_failed = reason
+        self._emit("on_register_failed", reason)
 
     def _authorized_register(self, m: sm.SipMessage) -> str:
         proxy = m.status_code == 407
@@ -847,6 +948,8 @@ class SipClient:
         )
         self._codec = new_codec
         self._chosen_pt = self._codec.payload_type
+        self._remote_offered_pts = sorted(sdp.offered_pts)
+        self._remote_offered_names = _offered_codec_names(sdp)
         if sdp.valid:
             self._sdp_negotiated = True
             # Including -1: a new offer without telephone-event must not
@@ -879,6 +982,8 @@ class SipClient:
         self._codec = codecs.DEFAULT
         self._chosen_pt = self._codec.payload_type
         self._remote_dtmf_pt = -1
+        self._remote_offered_pts = []
+        self._remote_offered_names = []
         self.rtp.dtmf_pt = -1
         self._sdp_negotiated = False
         self._remote_rtp_ip = ""
@@ -1279,6 +1384,9 @@ class SipClient:
         self._local_direction = "sendrecv"
         self.rtp.send_silence = True
         self.rtp.clear_tx_pause()
+        self.last_call_reason = reason
+        self.last_call_bytes_rx = self.rtp.bytes_received
+        self.last_call_bytes_tx = self.rtp.bytes_sent
         self._loop.create_task(self._stop_media())
         self._set_state(SipState.REGISTERED if self.registered else SipState.IDLE)
         self._emit("on_call_ended", reason)

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -307,7 +307,14 @@ class SipClient:
 
     def diagnostics_snapshot(self) -> dict:
         """Runtime SIP/RTP state for the HA diagnostics download (no secrets)."""
-        if self.rtp.running:
+        if self.rtp.running or self.state in (
+            SipState.INCOMING,
+            SipState.ANSWERING,
+            SipState.INVITING,
+            SipState.RINGING_OUT,
+        ):
+            # Live counters, including a new dialog that has not started RTP
+            # yet (counters are cleared in _begin_dialog_media).
             rx, tx = self.rtp.bytes_received, self.rtp.bytes_sent
         else:
             rx, tx = self.last_call_bytes_rx, self.last_call_bytes_tx
@@ -993,6 +1000,7 @@ class SipClient:
         self.rtp.send_silence = True
         self.rtp.clear_tx_pause()
         self.rtp.set_expect_rx(True)
+        self.rtp.reset_byte_counters()
 
     def _sync_media_endpoint(self, old_ip: str, old_port: int) -> None:
         """Retarget a live RTP session, or start one once a real address arrives."""

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -68,6 +68,15 @@ class SipCallbacks:
 
 _HOLD_IPS = frozenset({"0.0.0.0", "0:0:0:0:0:0:0:0", "::"})
 _INFO_DTMF_TYPES = ("application/dtmf-relay", "application/dtmf", "audio/telephone-event")
+_DIALOG_STATES = frozenset(
+    {
+        SipState.INVITING,
+        SipState.RINGING_OUT,
+        SipState.INCOMING,
+        SipState.ANSWERING,
+        SipState.IN_CALL,
+    }
+)
 
 
 def _dtmf_from_token(token: str) -> str | None:
@@ -307,14 +316,10 @@ class SipClient:
 
     def diagnostics_snapshot(self) -> dict:
         """Runtime SIP/RTP state for the HA diagnostics download (no secrets)."""
-        if self.rtp.running or self.state in (
-            SipState.INCOMING,
-            SipState.ANSWERING,
-            SipState.INVITING,
-            SipState.RINGING_OUT,
-        ):
-            # Live counters, including a new dialog that has not started RTP
-            # yet (counters are cleared in _begin_dialog_media).
+        if self.rtp.running or self.state in _DIALOG_STATES:
+            # Live counters, including a dialog that has not started RTP yet
+            # (bind failure / offerless INVITE). Counters are cleared in
+            # _begin_dialog_media so this cannot inherit the previous call.
             rx, tx = self.rtp.bytes_received, self.rtp.bytes_sent
         else:
             rx, tx = self.last_call_bytes_rx, self.last_call_bytes_tx

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -443,7 +443,7 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 
 ---
 
-### [ ] P1-2. diagnostics 플랫폼
+### [x] P1-2. diagnostics 플랫폼
 
 **대상** 새 파일 `custom_components/sip/diagnostics.py`
 
@@ -456,6 +456,19 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 
 **수용 기준** `async_redact_data`로 크리덴셜이 제거되고, diagnostics 다운로드 결과만으로
 "등록 실패 / 코덱 불일치 / one-way audio" 세 가지를 구분할 수 있다.
+
+**추가된 테스트** (`tests/test_diagnostics.py`)
+- `test_mask_number_keeps_last_two_digits`
+- `test_collect_diagnostics_redacts_password_and_masks_history`
+- `test_diagnostics_snapshot_registration_failure`
+- `test_diagnostics_snapshot_codec_mismatch`
+- `test_diagnostics_snapshot_matching_codec_is_not_mismatch`
+- `test_diagnostics_snapshot_one_way_audio`
+- `test_rtp_byte_counters_count_pcm_not_dtmf`
+- `test_async_get_config_entry_diagnostics_redacts`
+
+구분 키: `sip.registration.last_failure`, `sip.codec.mismatch`, `sip.rtp.audio_path`
+(`no_rx` / `no_tx` / `bidirectional` / `none`).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -464,6 +464,7 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 - `test_diagnostics_snapshot_codec_mismatch`
 - `test_diagnostics_snapshot_matching_codec_is_not_mismatch`
 - `test_diagnostics_snapshot_one_way_audio`
+- `test_diagnostics_no_media_call_does_not_inherit_previous_rtp_bytes`
 - `test_rtp_byte_counters_count_pcm_not_dtmf`
 - `test_async_get_config_entry_diagnostics_redacts`
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,215 @@
+"""Config-entry diagnostics: redaction and registration / codec / one-way audio (P1-2)."""
+from __future__ import annotations
+
+import asyncio
+import struct
+import sys
+import types
+from unittest.mock import MagicMock
+
+from test_pure import _load_component_module, rtp_session, sip_client, sm
+
+
+def _redact(data, to_redact):
+    if isinstance(data, dict):
+        return {
+            key: "**REDACTED**" if key in to_redact else _redact(value, to_redact)
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [_redact(item, to_redact) for item in data]
+    return data
+
+
+_diag_mod = types.ModuleType("homeassistant.components.diagnostics")
+_diag_mod.async_redact_data = _redact
+sys.modules["homeassistant.components.diagnostics"] = _diag_mod
+mock_components = sys.modules.get("homeassistant.components")
+if isinstance(mock_components, MagicMock):
+    mock_components.diagnostics = _diag_mod
+
+diagnostics = _load_component_module("diagnostics")
+
+
+def _pcmu(seq=1, ssrc=0x1234):
+    return bytes([0x80, 0]) + struct.pack("!HII", seq, 100, ssrc) + b"\xff" * 160
+
+
+def test_mask_number_keeps_last_two_digits():
+    assert diagnostics.mask_number("01012345678") == "*********78"
+    assert diagnostics.mask_number("sip:1001@pbx.example") == "sip:**01@pbx.example"
+    assert diagnostics.mask_number("12") == "12"
+    assert diagnostics.mask_number("") == ""
+    assert diagnostics.mask_number(None) is None
+
+
+def test_collect_diagnostics_redacts_password_and_masks_history():
+    payload = diagnostics.collect_diagnostics(
+        {
+            "server": "pbx.example",
+            "username": "100",
+            "password": "super-secret",
+            "authentication_username": "auth100",
+            "local_rtp_port": 7078,
+        },
+        {
+            "call_history": [
+                {
+                    "number": "01012345678",
+                    "name": "Kitchen",
+                    "direction": "incoming",
+                    "reason": "remote_bye",
+                }
+            ],
+            "call_direction": "incoming",
+            "call_number": "01012345678",
+            "call_status": "answered",
+        },
+    )
+    redacted = _redact(payload, diagnostics.TO_REDACT)
+    assert redacted["config"]["password"] == "**REDACTED**"
+    assert redacted["config"]["authentication_username"] == "**REDACTED**"
+    assert redacted["config"]["server"] == "pbx.example"
+    assert redacted["config"]["username"] == "100"
+    assert payload["call_history"][0]["number"] == "*********78"
+    assert payload["call_history"][0]["name"] == "Kitchen"
+    assert payload["current_call"]["number"] == "*********78"
+
+
+def test_diagnostics_snapshot_registration_failure():
+    if sip_client is None:
+        return
+
+    async def run():
+        failed = []
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example", password="secret"),
+            sip_client.SipCallbacks(on_register_failed=failed.append),
+        )
+        client._reg_cseq = 1
+        client._handle_register_response(
+            sm.parse_sip_message(
+                "SIP/2.0 403 Forbidden\r\nCSeq: 1 REGISTER\r\n\r\n"
+            )
+        )
+        return client.diagnostics_snapshot(), failed
+
+    snap, failed = asyncio.run(run())
+    assert failed == ["403 Forbidden"]
+    assert snap["registration"]["registered"] is False
+    assert snap["registration"]["last_failure"] == "403 Forbidden"
+    assert "secret" not in str(snap)
+
+
+def test_diagnostics_snapshot_codec_mismatch():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        sdp = sm.parse_sdp(
+            "v=0\r\nc=IN IP4 203.0.113.8\r\n"
+            "m=audio 5004 RTP/AVP 96 101\r\n"
+            "a=rtpmap:96 opus/48000/2\r\n"
+            "a=rtpmap:101 telephone-event/8000\r\n"
+        )
+        client._apply_remote_sdp(sdp)
+        return client.diagnostics_snapshot()
+
+    snap = asyncio.run(run())
+    assert snap["codec"]["mismatch"] is True
+    assert snap["codec"]["remote_offered"] == []
+    assert 96 in snap["codec"]["remote_offered_pts"]
+    assert snap["codec"]["negotiated"] == "PCMU"
+
+
+def test_diagnostics_snapshot_matching_codec_is_not_mismatch():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        sdp = sm.parse_sdp(
+            "v=0\r\nc=IN IP4 203.0.113.8\r\n"
+            "m=audio 5004 RTP/AVP 9 0 101\r\n"
+            "a=rtpmap:9 G722/8000\r\n"
+        )
+        client._apply_remote_sdp(sdp)
+        return client.diagnostics_snapshot()
+
+    snap = asyncio.run(run())
+    assert snap["codec"]["mismatch"] is False
+    assert snap["codec"]["negotiated"] == "G722"
+    assert "G722" in snap["codec"]["remote_offered"]
+
+
+def test_diagnostics_snapshot_one_way_audio():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.rtp.bytes_sent = 32000
+        client.rtp.bytes_received = 0
+        client.last_call_bytes_tx = 32000
+        client.last_call_bytes_rx = 0
+        client.last_call_reason = "media_timeout"
+        no_rx = client.diagnostics_snapshot()
+        client.rtp.bytes_received = 16000
+        client.last_call_bytes_rx = 16000
+        both = client.diagnostics_snapshot()
+        return no_rx, both
+
+    no_rx, both = asyncio.run(run())
+    assert no_rx["rtp"]["audio_path"] == "no_rx"
+    assert no_rx["call"]["last_end_reason"] == "media_timeout"
+    assert both["rtp"]["audio_path"] == "bidirectional"
+
+
+def test_rtp_byte_counters_count_pcm_not_dtmf():
+    async def run():
+        session = rtp_session.RtpSession()
+        session.set_remote("192.0.2.1", 5004)
+        session._transport = MagicMock()
+        session._send_audio_packet(b"\x00" * 320)
+        session._receive_impl(_pcmu(), ("203.0.113.8", 20000))
+        te = bytes([0x80, 101]) + struct.pack("!HII", 2, 100, 0x1234) + bytes(
+            [1, 0x0A, 0x00, 0xA0]
+        )
+        session.dtmf_pt = 101
+        session._receive_impl(te, ("203.0.113.8", 20000))
+        return session.bytes_sent, session.bytes_received
+
+    sent, received = asyncio.run(run())
+    assert sent == 320
+    assert received == 320  # decoded PCMU frame
+
+
+def test_async_get_config_entry_diagnostics_redacts():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(
+            sip_client.SipConfig(server="pbx.example", password="secret")
+        )
+        client.last_caller = "01099998888"
+        entry = MagicMock()
+        entry.data = {
+            "server": "pbx.example",
+            "username": "100",
+            "password": "secret",
+            "authentication_username": "auth100",
+        }
+        entry.runtime_data = {
+            "client": client,
+            "call_history": [{"number": "01099998888", "reason": "local"}],
+        }
+        return await diagnostics.async_get_config_entry_diagnostics(MagicMock(), entry)
+
+    payload = asyncio.run(run())
+    assert payload["config"]["password"] == "**REDACTED**"
+    assert payload["config"]["authentication_username"] == "**REDACTED**"
+    assert "secret" not in str(payload)
+    assert payload["call_history"][0]["number"] == "*********88"
+    assert payload["sip"]["call"]["last_caller"] == "*********88"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -166,6 +166,37 @@ def test_diagnostics_snapshot_one_way_audio():
     assert both["rtp"]["audio_path"] == "bidirectional"
 
 
+def test_diagnostics_no_media_call_does_not_inherit_previous_rtp_bytes():
+    """486 / CANCEL / ring-timeout must not copy the previous call's PCM totals."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.registered = True
+        client.rtp.bytes_sent = 32000
+        client.rtp.bytes_received = 16000
+        client._end_call("local")
+        after_a = client.diagnostics_snapshot()
+        client._begin_dialog_media()
+        client.state = sip_client.SipState.RINGING_OUT
+        ringing = client.diagnostics_snapshot()
+        client._end_call("remote_reject")
+        after_b = client.diagnostics_snapshot()
+        return after_a, ringing, after_b
+
+    after_a, ringing, after_b = asyncio.run(run())
+    assert after_a["rtp"]["audio_path"] == "bidirectional"
+    assert after_a["call"]["last_end_reason"] == "local"
+    assert ringing["rtp"]["audio_path"] == "none"
+    assert ringing["rtp"]["bytes_received"] == 0
+    assert ringing["rtp"]["bytes_sent"] == 0
+    assert after_b["call"]["last_end_reason"] == "remote_reject"
+    assert after_b["rtp"]["audio_path"] == "none"
+    assert after_b["rtp"]["bytes_received"] == 0
+    assert after_b["rtp"]["bytes_sent"] == 0
+
+
 def test_rtp_byte_counters_count_pcm_not_dtmf():
     async def run():
         session = rtp_session.RtpSession()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -181,16 +181,21 @@ def test_diagnostics_no_media_call_does_not_inherit_previous_rtp_bytes():
         client._begin_dialog_media()
         client.state = sip_client.SipState.RINGING_OUT
         ringing = client.diagnostics_snapshot()
+        client.state = sip_client.SipState.IN_CALL
+        in_call_no_rtp = client.diagnostics_snapshot()
         client._end_call("remote_reject")
         after_b = client.diagnostics_snapshot()
-        return after_a, ringing, after_b
+        return after_a, ringing, in_call_no_rtp, after_b
 
-    after_a, ringing, after_b = asyncio.run(run())
+    after_a, ringing, in_call_no_rtp, after_b = asyncio.run(run())
     assert after_a["rtp"]["audio_path"] == "bidirectional"
     assert after_a["call"]["last_end_reason"] == "local"
     assert ringing["rtp"]["audio_path"] == "none"
     assert ringing["rtp"]["bytes_received"] == 0
     assert ringing["rtp"]["bytes_sent"] == 0
+    assert in_call_no_rtp["call"]["in_call"] is True
+    assert in_call_no_rtp["rtp"]["running"] is False
+    assert in_call_no_rtp["rtp"]["audio_path"] == "none"
     assert after_b["call"]["last_end_reason"] == "remote_reject"
     assert after_b["rtp"]["audio_path"] == "none"
     assert after_b["rtp"]["bytes_received"] == 0


### PR DESCRIPTION
## Summary
- Add `diagnostics.py` with `async_get_config_entry_diagnostics`. Passwords / auth usernames are `**REDACTED**`; call history numbers keep only the last two digits.
- SIP snapshot includes registration (`last_failure`), negotiated vs remote-offered codecs (`mismatch`), SDP vs latched RTP addresses, and PCM byte counts (`audio_path`: `no_rx` / `no_tx` / `bidirectional`).
- Wire `on_register_failed`, persist last-call end reason on history, and count RTP PCM TX/RX on the session so the download works after hangup.

## Test plan
- [x] `python -m pytest tests/` (191 passed on Python 3.14, ~5s)
- [x] `ruff check custom_components/ tests/`
- [ ] Optional: in HA, download diagnostics after a failed REGISTER / one-way call and confirm `sip.registration.last_failure`, `sip.codec.mismatch`, and `sip.rtp.audio_path`


Made with [Cursor](https://cursor.com)