### PR TITLE
feat: expose codec, audio path, and call duration on entities (P1-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A native custom integration for Home Assistant to connect directly to a SIP serv
 - **Interactive Voice Response (IVR) Engine**: Construct nested DTMF automated phone trees with TTS prompt templates, custom PIN authentication, and native Home Assistant service triggers.
 - **Wideband Audio (G.722)**: Negotiates G.722 (16 kHz) when the remote party supports it, falling back to G.711 µ-law / A-law. Voice Assist receives true 16 kHz PCM on G.722 calls instead of upsampled narrowband.
 - **Continuous Voice Assist**: During an active call, `sip.start_assist` keeps listening for follow-up commands until silence, a turn limit, or hangup — no need to redial between commands.
-- **Sensors**: Exposes real-time registration status, call state (line active), and last caller ID.
+- **Sensors**: Exposes registration status, last caller ID, negotiated codec, last-call audio path (`none` / `no_rx` / `no_tx` / `bidirectional`), hangup reason, and a bidirectional-audio binary sensor.
 
 ## Installation
 
@@ -673,7 +673,7 @@ action:
 ## Troubleshooting
 
 - **Registration fails**: Double-check the SIP extension credentials and host IP address. Ensure your firewall or FreePBX settings permit UDP traffic on port `5060` from the Home Assistant host.
-- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Ensure the RTP port range (defaults starting at `7078`) is open and routed properly. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** — `sip.rtp.audio_path` is `no_rx` / `no_tx` / `bidirectional`, `sip.codec.mismatch` flags an offer we cannot negotiate, and `sip.registration.last_failure` shows why REGISTER failed. Passwords are redacted; phone numbers are masked.
+- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Ensure the RTP port range (defaults starting at `7078`) is open and routed properly. After a call, check **Call Audio** (`no_rx` means we sent but heard nothing) and **Bidirectional Audio**; the phone-line media player also shows `call_duration`, byte counts, and `audio_path`. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** for SDP vs latched addresses. Passwords are redacted; phone numbers are masked.
 - **FFmpeg errors**: Ensure that the `ffmpeg` system binary is installed and accessible in your Home Assistant path, as it is utilized for audio transcoding.
 - **SIP / RTP protocol trace**: Off by default. To capture signalling (INVITE / 200 OK / REGISTER) and a 5-second RTP summary without putting digest credentials in the log, add this to `configuration.yaml` and restart:
 

--- a/custom_components/sip/binary_sensor.py
+++ b/custom_components/sip/binary_sensor.py
@@ -1,6 +1,7 @@
 """Binary sensor platforms for the SIP Client integration."""
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -11,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .helpers import build_device_info
+from .media_status import media_view
 from .sip_client.sip_client import SipClient, SipState
 
 
@@ -24,6 +26,7 @@ async def async_setup_entry(
 
     binary_sensors = [
         SipCallActiveSensor(entry, entry_data),
+        SipAudioBidirectionalSensor(entry, entry_data),
     ]
 
     async_add_entities(binary_sensors)
@@ -80,4 +83,48 @@ class SipCallActiveSensor(BinarySensorEntity):
             "sip_state": str(state),
             "in_call": self._client.in_call,
             "username": self._config.username,
+        }
+
+
+class SipAudioBidirectionalSensor(BinarySensorEntity):
+    """On when the last/current call had audio in both directions."""
+
+    _attr_icon = "mdi:ear-hearing"
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
+        self.entry = entry
+        self.entry_data = entry_data
+        self._client: SipClient = entry_data["client"]
+        self._config = entry_data["config"]
+        self._attr_unique_id = f"{entry.entry_id}_audio_bidirectional"
+        self._attr_translation_key = "audio_bidirectional"
+        self._attr_device_info = build_device_info(entry, self._config)
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_state_update_{self.entry.entry_id}",
+                self._update_callback,
+            )
+        )
+
+    @callback
+    def _update_callback(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        return bool(
+            media_view(self._client, self.entry_data, time.time())["audio_confirmed"]
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        view = media_view(self._client, self.entry_data, time.time())
+        return {
+            "audio_path": view["audio_path"],
+            "bytes_received": view["bytes_received"],
+            "bytes_sent": view["bytes_sent"],
         }

--- a/custom_components/sip/media_player.py
+++ b/custom_components/sip/media_player.py
@@ -1,6 +1,7 @@
 """Media Player platform for SIP Client integration."""
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from homeassistant.components import media_source
@@ -20,6 +21,7 @@ from homeassistant.helpers.network import get_url
 
 from .const import DOMAIN, LOGGER
 from .helpers import build_device_info, get_ffmpeg_bin
+from .media_status import media_view
 from .sip_client.audio import FfmpegAudioSource
 from .sip_client.sip_client import SipClient, SipState
 
@@ -130,11 +132,18 @@ class SipMediaPlayer(MediaPlayerEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose call details for dashboards/automations."""
         state = self.entry_data.get("state", SipState.IDLE)
+        view = media_view(self._client, self.entry_data, time.time())
         return {
             "sip_state": str(state),
             "remote_party": self.entry_data.get("call_number") or "",
             "remote_name": self.entry_data.get("last_caller") or "",
             "call_direction": self.entry_data.get("call_direction"),
+            "call_duration": view["call_duration"],
+            "codec": view["codec"],
+            "bytes_received": view["bytes_received"],
+            "bytes_sent": view["bytes_sent"],
+            "audio_path": view["audio_path"],
+            "last_end_reason": view["last_end_reason"],
         }
 
     # -- controls -------------------------------------------------------

--- a/custom_components/sip/media_status.py
+++ b/custom_components/sip/media_status.py
@@ -1,0 +1,58 @@
+"""Call-media view shared by sensors, binary_sensor, and media_player.
+
+No Home Assistant imports. Tests load this module standalone.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# ~100 ms of 8 kHz s16le (or ~50 ms of 16 kHz G.722). Filters a stray packet.
+AUDIO_CONFIRM_BYTES = 1600
+
+AUDIO_PATH_OPTIONS = ("none", "no_rx", "no_tx", "bidirectional")
+CODEC_OPTIONS = ("G722", "PCMU", "PCMA")
+
+
+def audio_confirmed(rx: int, tx: int, threshold: int = AUDIO_CONFIRM_BYTES) -> bool:
+    """True when both directions carried more than a blip of PCM."""
+    return rx >= threshold and tx >= threshold
+
+
+def call_duration_seconds(runtime: dict[str, Any], now: float) -> int | None:
+    """Live duration while connected, else the last history entry."""
+    connect = runtime.get("call_connect_time")
+    if connect:
+        return max(0, int(now - connect))
+    history = runtime.get("call_history") or []
+    if not history:
+        return None
+    duration = history[0].get("duration")
+    if duration is None:
+        return None
+    return int(duration)
+
+
+def media_view(
+    client: Any | None, runtime: dict[str, Any], now: float
+) -> dict[str, Any]:
+    """Flatten SIP diagnostics into entity-friendly fields."""
+    snap = client.diagnostics_snapshot() if client is not None else {}
+    rtp = snap.get("rtp") or {}
+    codec = snap.get("codec") or {}
+    call = snap.get("call") or {}
+    rx = int(rtp.get("bytes_received") or 0)
+    tx = int(rtp.get("bytes_sent") or 0)
+    path = rtp.get("audio_path") or "none"
+    return {
+        "codec": codec.get("negotiated"),
+        "payload_type": codec.get("payload_type"),
+        "sample_rate": codec.get("sample_rate"),
+        "telephone_event_pt": codec.get("telephone_event_pt"),
+        "bytes_received": rx,
+        "bytes_sent": tx,
+        "audio_path": path,
+        "audio_confirmed": audio_confirmed(rx, tx),
+        "last_end_reason": call.get("last_end_reason"),
+        "call_duration": call_duration_seconds(runtime, now),
+        "in_call": bool(call.get("in_call")),
+    }

--- a/custom_components/sip/sensor.py
+++ b/custom_components/sip/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import time
 from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
@@ -12,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .helpers import build_device_info
+from .media_status import AUDIO_PATH_OPTIONS, CODEC_OPTIONS, media_view
 from .sip_client.sip_client import SipClient, SipState
 
 
@@ -26,6 +28,9 @@ async def async_setup_entry(
     sensors = [
         SipRegistrationSensor(entry, entry_data),
         SipLastCallSensor(entry, entry_data),
+        SipCodecSensor(entry, entry_data),
+        SipCallAudioSensor(entry, entry_data),
+        SipLastCallReasonSensor(entry, entry_data),
     ]
 
     async_add_entities(sensors)
@@ -139,9 +144,114 @@ class SipLastCallSensor(SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return last caller metadata."""
+        view = media_view(self._client, self.entry_data, time.time())
         return {
             "last_caller": self._client.last_caller,
             "timestamp": self._timestamp,
             "username": self._config.username,
             "call_history": self.entry_data.get("call_history", []),
+            "last_end_reason": view["last_end_reason"],
+            "bytes_received": view["bytes_received"],
+            "bytes_sent": view["bytes_sent"],
+            "audio_path": view["audio_path"],
+            "codec": view["codec"],
         }
+
+
+class _SipMediaSensor(SensorEntity):
+    """Sensor that refreshes from the SIP state dispatcher."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        entry_data: dict[str, Any],
+        unique_suffix: str,
+        translation_key: str,
+    ) -> None:
+        self.entry = entry
+        self.entry_data = entry_data
+        self._client: SipClient = entry_data["client"]
+        self._config = entry_data["config"]
+        self._attr_unique_id = f"{entry.entry_id}_{unique_suffix}"
+        self._attr_translation_key = translation_key
+        self._attr_device_info = build_device_info(entry, self._config)
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_state_update_{self.entry.entry_id}",
+                self._update_callback,
+            )
+        )
+
+    @callback
+    def _update_callback(self) -> None:
+        self.async_write_ha_state()
+
+    def _view(self) -> dict[str, Any]:
+        return media_view(self._client, self.entry_data, time.time())
+
+
+class SipCodecSensor(_SipMediaSensor):
+    """Negotiated audio codec of the current / last call."""
+
+    _attr_icon = "mdi:codec"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(CODEC_OPTIONS)
+
+    def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
+        super().__init__(entry, entry_data, "negotiated_codec", "negotiated_codec")
+
+    @property
+    def native_value(self) -> str | None:
+        return self._view()["codec"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        view = self._view()
+        return {
+            "payload_type": view["payload_type"],
+            "sample_rate": view["sample_rate"],
+            "telephone_event_pt": view["telephone_event_pt"],
+        }
+
+
+class SipCallAudioSensor(_SipMediaSensor):
+    """Last-call audio path: none / no_rx / no_tx / bidirectional."""
+
+    _attr_icon = "mdi:ear-hearing"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(AUDIO_PATH_OPTIONS)
+
+    def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
+        super().__init__(entry, entry_data, "call_audio", "call_audio")
+
+    @property
+    def native_value(self) -> str:
+        return self._view()["audio_path"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        view = self._view()
+        return {
+            "bytes_received": view["bytes_received"],
+            "bytes_sent": view["bytes_sent"],
+            "last_end_reason": view["last_end_reason"],
+            "codec": view["codec"],
+        }
+
+
+class SipLastCallReasonSensor(_SipMediaSensor):
+    """SIP hangup / failure reason of the last call."""
+
+    _attr_icon = "mdi:phone-hangup"
+
+    def __init__(self, entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
+        super().__init__(entry, entry_data, "last_call_reason", "last_call_reason")
+
+    @property
+    def native_value(self) -> str | None:
+        return self._view()["last_end_reason"]

--- a/custom_components/sip/strings.json
+++ b/custom_components/sip/strings.json
@@ -65,11 +65,29 @@
           "incoming": "Incoming",
           "outgoing": "Outgoing"
         }
+      },
+      "negotiated_codec": {
+        "name": "Negotiated Codec"
+      },
+      "call_audio": {
+        "name": "Call Audio",
+        "state": {
+          "none": "No media",
+          "no_rx": "No receive (one-way)",
+          "no_tx": "No send (one-way)",
+          "bidirectional": "Bidirectional"
+        }
+      },
+      "last_call_reason": {
+        "name": "Last Call Reason"
       }
     },
     "binary_sensor": {
       "call_active": {
         "name": "Call Active"
+      },
+      "audio_bidirectional": {
+        "name": "Bidirectional Audio"
       }
     },
     "switch": {

--- a/custom_components/sip/translations/de.json
+++ b/custom_components/sip/translations/de.json
@@ -65,11 +65,29 @@
           "incoming": "Eingehend",
           "outgoing": "Ausgehend"
         }
+      },
+      "negotiated_codec": {
+        "name": "Verhandelter Codec"
+      },
+      "call_audio": {
+        "name": "Anruf-Audio",
+        "state": {
+          "none": "Kein Medium",
+          "no_rx": "Kein Empfang (einseitig)",
+          "no_tx": "Kein Senden (einseitig)",
+          "bidirectional": "Bidirektional"
+        }
+      },
+      "last_call_reason": {
+        "name": "Letzter Auflegegrund"
       }
     },
     "binary_sensor": {
       "call_active": {
         "name": "Anruf aktiv"
+      },
+      "audio_bidirectional": {
+        "name": "Bidirektionales Audio"
       }
     },
     "switch": {

--- a/custom_components/sip/translations/en.json
+++ b/custom_components/sip/translations/en.json
@@ -65,11 +65,29 @@
           "incoming": "Incoming",
           "outgoing": "Outgoing"
         }
+      },
+      "negotiated_codec": {
+        "name": "Negotiated Codec"
+      },
+      "call_audio": {
+        "name": "Call Audio",
+        "state": {
+          "none": "No media",
+          "no_rx": "No receive (one-way)",
+          "no_tx": "No send (one-way)",
+          "bidirectional": "Bidirectional"
+        }
+      },
+      "last_call_reason": {
+        "name": "Last Call Reason"
       }
     },
     "binary_sensor": {
       "call_active": {
         "name": "Call Active"
+      },
+      "audio_bidirectional": {
+        "name": "Bidirectional Audio"
       }
     },
     "switch": {

--- a/custom_components/sip/translations/ko.json
+++ b/custom_components/sip/translations/ko.json
@@ -65,11 +65,29 @@
           "incoming": "수신",
           "outgoing": "발신"
         }
+      },
+      "negotiated_codec": {
+        "name": "협상 코덱"
+      },
+      "call_audio": {
+        "name": "통화 음성",
+        "state": {
+          "none": "미디어 없음",
+          "no_rx": "수신 없음 (편도)",
+          "no_tx": "송신 없음 (편도)",
+          "bidirectional": "양방향"
+        }
+      },
+      "last_call_reason": {
+        "name": "최근 통화 종료 사유"
       }
     },
     "binary_sensor": {
       "call_active": {
         "name": "통화 활성화"
+      },
+      "audio_bidirectional": {
+        "name": "양방향 음성"
       }
     },
     "switch": {

--- a/custom_components/sip/translations/ru.json
+++ b/custom_components/sip/translations/ru.json
@@ -65,11 +65,29 @@
           "incoming": "Входящий",
           "outgoing": "Исходящий"
         }
+      },
+      "negotiated_codec": {
+        "name": "Согласованный кодек"
+      },
+      "call_audio": {
+        "name": "Аудио вызова",
+        "state": {
+          "none": "Нет медиа",
+          "no_rx": "Нет приёма (одностороннее)",
+          "no_tx": "Нет передачи (одностороннее)",
+          "bidirectional": "Двустороннее"
+        }
+      },
+      "last_call_reason": {
+        "name": "Причина завершения"
       }
     },
     "binary_sensor": {
       "call_active": {
         "name": "Вызов активен"
+      },
+      "audio_bidirectional": {
+        "name": "Двустороннее аудио"
       }
     },
     "switch": {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -473,7 +473,7 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 
 ---
 
-### [ ] P1-3. 미디어 상태 노출
+### [x] P1-3. 미디어 상태 노출
 
 **근거** `NullSink.bytes_received`가 이미 있는데 노출되지 않는다.
 
@@ -483,6 +483,17 @@ P0-2 latching은 RTP 단위 테스트로 `test_pure.py`에 남아 있다.
 - 통화 시간(초)을 media_player 속성에 노출.
 
 **수용 기준** 사용자가 통화 후 엔티티만 보고 "음성이 한쪽만 흐른다"를 판단할 수 있다.
+
+**추가된 테스트** (`tests/test_media_status.py`)
+- `test_audio_confirmed_requires_both_directions_above_threshold`
+- `test_call_duration_live_then_history`
+- `test_media_view_one_way_is_not_confirmed`
+- `test_media_view_bidirectional_is_confirmed`
+- `test_media_view_from_real_sip_client_one_way`
+
+엔티티: `sensor.negotiated_codec`, `sensor.call_audio` (`none`/`no_rx`/`no_tx`/`bidirectional`),
+`sensor.last_call_reason`, `binary_sensor.audio_bidirectional`.
+media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sent`.
 
 ---
 

--- a/tests/test_media_status.py
+++ b/tests/test_media_status.py
@@ -1,0 +1,98 @@
+"""P1-3 media status view: one-way vs bidirectional from entity fields."""
+from __future__ import annotations
+
+import asyncio
+
+from test_pure import _load_component_module, sip_client
+
+media_status = _load_component_module("media_status")
+
+
+class _FakeClient:
+    def __init__(self, snap: dict) -> None:
+        self._snap = snap
+
+    def diagnostics_snapshot(self) -> dict:
+        return self._snap
+
+
+def test_audio_confirmed_requires_both_directions_above_threshold():
+    thresh = media_status.AUDIO_CONFIRM_BYTES
+    assert media_status.audio_confirmed(thresh, thresh) is True
+    assert media_status.audio_confirmed(thresh - 1, thresh) is False
+    assert media_status.audio_confirmed(thresh, thresh - 1) is False
+    assert media_status.audio_confirmed(0, 32000) is False
+    assert media_status.audio_confirmed(32000, 0) is False
+
+
+def test_call_duration_live_then_history():
+    now = 1_000.0
+    live = media_status.call_duration_seconds(
+        {"call_connect_time": now - 12.4}, now
+    )
+    assert live == 12
+    ended = media_status.call_duration_seconds(
+        {"call_history": [{"duration": 41}]}, now
+    )
+    assert ended == 41
+    assert media_status.call_duration_seconds({}, now) is None
+
+
+def test_media_view_one_way_is_not_confirmed():
+    client = _FakeClient(
+        {
+            "codec": {"negotiated": "PCMU", "payload_type": 0, "sample_rate": 8000},
+            "rtp": {
+                "bytes_received": 0,
+                "bytes_sent": 32000,
+                "audio_path": "no_rx",
+            },
+            "call": {"last_end_reason": "media_timeout", "in_call": False},
+        }
+    )
+    view = media_status.media_view(client, {}, 0.0)
+    assert view["audio_path"] == "no_rx"
+    assert view["audio_confirmed"] is False
+    assert view["bytes_sent"] == 32000
+    assert view["bytes_received"] == 0
+    assert view["last_end_reason"] == "media_timeout"
+    assert view["codec"] == "PCMU"
+
+
+def test_media_view_bidirectional_is_confirmed():
+    thresh = media_status.AUDIO_CONFIRM_BYTES
+    client = _FakeClient(
+        {
+            "codec": {"negotiated": "G722", "payload_type": 9, "sample_rate": 16000},
+            "rtp": {
+                "bytes_received": thresh,
+                "bytes_sent": thresh,
+                "audio_path": "bidirectional",
+            },
+            "call": {"last_end_reason": "remote_bye", "in_call": False},
+        }
+    )
+    view = media_status.media_view(
+        client, {"call_history": [{"duration": 8}]}, 0.0
+    )
+    assert view["audio_path"] == "bidirectional"
+    assert view["audio_confirmed"] is True
+    assert view["call_duration"] == 8
+    assert view["codec"] == "G722"
+
+
+def test_media_view_from_real_sip_client_one_way():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.last_call_bytes_tx = 32000
+        client.last_call_bytes_rx = 0
+        client.last_call_reason = "media_timeout"
+        return media_status.media_view(client, {}, 0.0)
+
+    view = asyncio.run(run())
+    assert view["audio_path"] == "no_rx"
+    assert view["audio_confirmed"] is False
+    assert view["last_end_reason"] == "media_timeout"


### PR DESCRIPTION
## Summary
- Add sensors for negotiated codec, last-call audio path (`none` / `no_rx` / `no_tx` / `bidirectional` with RX/TX bytes), and hangup reason.
- Add `binary_sensor.audio_bidirectional` (both directions above ~100 ms of PCM).
- Expose `call_duration`, `audio_path`, and byte counts on the phone-line media player. Strings/translations for en/ko/de/ru.

## Test plan
- [x] `python -m pytest tests/` (197 passed on Python 3.14, ~5s)
- [x] `ruff check custom_components/ tests/`
- [ ] Optional: place a call, hang up, and confirm Call Audio is `bidirectional` (or `no_rx` on a one-way NAT failure) without opening diagnostics


Made with [Cursor](https://cursor.com)