### PR TITLE
fix: serialize RTP start/stop so a new call cannot skip media (P2-1)

### DIFF
--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -1437,6 +1437,14 @@ class SipClient:
         self.hangup(reason="media_timeout")
 
     # -- media ----------------------------------------------------------
+    def _apply_rtp_dest_if_changed(self) -> None:
+        """Retarget RTP if SDP moved the peer while a start was in flight."""
+        if not self._remote_rtp_ip or not self._remote_rtp_port:
+            return
+        dest = (self._remote_rtp_ip, self._remote_rtp_port)
+        if self.rtp.sdp_remote != dest:
+            self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
+
     async def _start_media(self) -> None:
         async with self._media_lock:
             session = self._media_session
@@ -1444,6 +1452,7 @@ class SipClient:
                 # Same dialog: ACK/UPDATE/re-INVITE can schedule a second
                 # start while the first is still binding. Do not bounce RTP.
                 if self._media_owner == session:
+                    self._apply_rtp_dest_if_changed()
                     return
                 await self._stop_media_unlocked()
             if not self._remote_rtp_ip or not self._remote_rtp_port:
@@ -1459,6 +1468,8 @@ class SipClient:
             if session != self._media_session:
                 await self.rtp.stop()
                 return
+            # SDP may have moved the peer during create_datagram_endpoint.
+            self._apply_rtp_dest_if_changed()
             self._media_active = True
             self._media_owner = session
             _LOGGER.info(

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -281,6 +281,9 @@ class SipClient:
         self._remote_dtmf_pt = -1
         self._sdp_negotiated = False
         self._media_active = False
+        self._media_lock = asyncio.Lock()
+        self._media_session = 0
+        self._media_owner: int | None = None
 
         self.rtp = RtpSession()
         self.rtp.media_timeout = float(self.config.media_timeout)
@@ -1400,7 +1403,9 @@ class SipClient:
         self.last_call_reason = reason
         self.last_call_bytes_rx = self.rtp.bytes_received
         self.last_call_bytes_tx = self.rtp.bytes_sent
-        self._loop.create_task(self._stop_media())
+        ended_session = self._media_session
+        self._media_session += 1
+        self._loop.create_task(self._stop_media_session(ended_session))
         self._set_state(SipState.REGISTERED if self.registered else SipState.IDLE)
         self._emit("on_call_ended", reason)
 
@@ -1433,31 +1438,51 @@ class SipClient:
 
     # -- media ----------------------------------------------------------
     async def _start_media(self) -> None:
-        if self._media_active:
-            return
-        if not self._remote_rtp_ip or not self._remote_rtp_port:
-            _LOGGER.warning("No remote RTP endpoint; media not started")
-            return
-        self.rtp.set_codec(self._codec)
-        self.rtp.dtmf_pt = self._remote_dtmf_pt
-        self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
-        self.rtp.on_audio = self._on_rx_audio
-        self.rtp.on_dtmf = self._on_rx_dtmf
-        if not await self.rtp.start(self.config.local_rtp_port):
-            return
-        self._media_active = True
-        _LOGGER.info(
-            "Media started: remote %s:%s pt=%s dtmf_pt=%s",
-            self._remote_rtp_ip, self._remote_rtp_port, self._chosen_pt, self._remote_dtmf_pt,
-        )
+        async with self._media_lock:
+            session = self._media_session
+            if self._media_active:
+                await self._stop_media_unlocked()
+            if not self._remote_rtp_ip or not self._remote_rtp_port:
+                _LOGGER.warning("No remote RTP endpoint; media not started")
+                return
+            self.rtp.set_codec(self._codec)
+            self.rtp.dtmf_pt = self._remote_dtmf_pt
+            self.rtp.set_remote(self._remote_rtp_ip, self._remote_rtp_port)
+            self.rtp.on_audio = self._on_rx_audio
+            self.rtp.on_dtmf = self._on_rx_dtmf
+            if not await self.rtp.start(self.config.local_rtp_port):
+                return
+            if session != self._media_session:
+                await self.rtp.stop()
+                return
+            self._media_active = True
+            self._media_owner = session
+            _LOGGER.info(
+                "Media started: remote %s:%s pt=%s dtmf_pt=%s",
+                self._remote_rtp_ip, self._remote_rtp_port, self._chosen_pt, self._remote_dtmf_pt,
+            )
 
     async def _stop_media(self) -> None:
+        async with self._media_lock:
+            await self._stop_media_unlocked()
+
+    async def _stop_media_session(self, session: int) -> None:
+        """Stop RTP only if this session still owns the socket.
+
+        A hangup schedules this as a background task. The next call may
+        already have started media under a newer ``_media_session``; a late
+        stop must not tear that down.
+        """
+        async with self._media_lock:
+            if self._media_owner is not None and self._media_owner != session:
+                return
+            await self._stop_media_unlocked()
+
+    async def _stop_media_unlocked(self) -> None:
         self._cancel_source()
-        if not self._media_active:
-            await self.rtp.stop()
-            return
         await self.rtp.stop()
         self._media_active = False
+        self._media_owner = None
 
     def _on_rx_audio(self, pcm_le: bytes) -> None:
         try:

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -1441,6 +1441,10 @@ class SipClient:
         async with self._media_lock:
             session = self._media_session
             if self._media_active:
+                # Same dialog: ACK/UPDATE/re-INVITE can schedule a second
+                # start while the first is still binding. Do not bounce RTP.
+                if self._media_owner == session:
+                    return
                 await self._stop_media_unlocked()
             if not self._remote_rtp_ip or not self._remote_rtp_port:
                 _LOGGER.warning("No remote RTP endpoint; media not started")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -514,6 +514,7 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 **추가된 테스트**
 - `test_media_start_after_hangup_does_not_early_return`
 - `test_late_media_stop_does_not_kill_new_session`
+- `test_duplicate_start_media_same_session_does_not_restart`
 - `test_auto_answer_right_after_bye_starts_media`
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -499,10 +499,10 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 ## P2 — 자원 관리·동시성
 
-### [ ] P2-1. 미디어 생명주기 직렬화
+### [x] P2-1. 미디어 생명주기 직렬화
 
-**근거** §1.3-6. `_end_call`(:1076)이 `_stop_media`를 fire-and-forget으로 던지고 즉시
-상태를 전이시켜 `_start_media`(:1086)와 경합한다.
+**근거** §1.3-6. `_end_call`이 `_stop_media`를 fire-and-forget으로 던지고 즉시
+상태를 전이시켜 `_start_media`와 경합한다.
 
 **작업** `SipClient`에 `asyncio.Lock`을 두고 `_start_media`/`_stop_media`를 직렬화한다.
 `_end_call`이 던지는 태스크가 완료되기 전에 새 통화가 시작되어도 순서가 보장되게 한다.
@@ -510,6 +510,11 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 **수용 기준** 통화 종료 직후 즉시 새 착신을 auto-answer하는 시나리오에서
 새 통화의 RTP 세션이 정상 시작된다(테스트).
+
+**추가된 테스트**
+- `test_media_start_after_hangup_does_not_early_return`
+- `test_late_media_stop_does_not_kill_new_session`
+- `test_auto_answer_right_after_bye_starts_media`
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -515,6 +515,7 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 - `test_media_start_after_hangup_does_not_early_return`
 - `test_late_media_stop_does_not_kill_new_session`
 - `test_duplicate_start_media_same_session_does_not_restart`
+- `test_start_media_retargets_if_endpoint_changes_during_bind`
 - `test_auto_answer_right_after_bye_starts_media`
 
 ---

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1650,6 +1650,51 @@ def test_duplicate_start_media_same_session_does_not_restart():
     assert owner == 0
 
 
+def test_start_media_retargets_if_endpoint_changes_during_bind():
+    """re-INVITE during bind must not keep sending to the first SDP dest."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.state = sip_client.SipState.IN_CALL
+        client._remote_rtp_ip = "198.51.100.10"
+        client._remote_rtp_port = 4000
+        starts: list[int] = []
+        stops: list[int] = []
+        bound = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_start(port):
+            starts.append(port)
+            bound.set()
+            await release.wait()
+            return True
+
+        async def track_stop():
+            stops.append(1)
+
+        with (
+            patch.object(client.rtp, "stop", side_effect=track_stop),
+            patch.object(client.rtp, "start", side_effect=slow_start),
+        ):
+            first = client._loop.create_task(client._start_media())
+            await bound.wait()
+            client._remote_rtp_ip = "203.0.113.8"
+            client._remote_rtp_port = 5004
+            client._sync_media_endpoint("198.51.100.10", 4000)
+            release.set()
+            await first
+            await asyncio.sleep(0)
+        return starts, stops, client.rtp.sdp_remote, client._media_active
+
+    starts, stops, remote, active = asyncio.run(run())
+    assert starts == [7078]
+    assert stops == []
+    assert remote == ("203.0.113.8", 5004)
+    assert active is True
+
+
 def test_auto_answer_right_after_bye_starts_media():
     """Intercom: BYE then a new auto-answer INVITE before stop finishes."""
     if sip_client is None:

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1607,6 +1607,49 @@ def test_late_media_stop_does_not_kill_new_session():
     assert stops == [1]
 
 
+def test_duplicate_start_media_same_session_does_not_restart():
+    """ACK/re-INVITE must not tear down RTP that this dialog just started."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._remote_rtp_ip = "198.51.100.10"
+        client._remote_rtp_port = 4000
+        starts: list[int] = []
+        stops: list[int] = []
+        bound = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_start(port):
+            starts.append(port)
+            bound.set()
+            await release.wait()
+            return True
+
+        async def track_stop():
+            stops.append(1)
+
+        with (
+            patch.object(client.rtp, "stop", side_effect=track_stop),
+            patch.object(client.rtp, "start", side_effect=slow_start),
+        ):
+            first = client._loop.create_task(client._start_media())
+            await bound.wait()
+            second = client._loop.create_task(client._start_media())
+            release.set()
+            await first
+            await second
+            await client._start_media()
+        return starts, stops, client._media_active, client._media_owner
+
+    starts, stops, active, owner = asyncio.run(run())
+    assert starts == [7078]
+    assert stops == []
+    assert active is True
+    assert owner == 0
+
+
 def test_auto_answer_right_after_bye_starts_media():
     """Intercom: BYE then a new auto-answer INVITE before stop finishes."""
     if sip_client is None:

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -1531,6 +1531,137 @@ def test_telephone_event_pt_does_not_leak_across_calls():
     assert second_pt == (-1, -1)
 
 
+def test_media_start_after_hangup_does_not_early_return():
+    """Hangup's fire-and-forget stop must not make the next start a no-op."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._remote_rtp_ip = "198.51.100.10"
+        client._remote_rtp_port = 4000
+        order: list[str] = []
+
+        async def slow_stop():
+            order.append("stop")
+            await asyncio.sleep(0.02)
+
+        async def fake_start(port):
+            order.append("start")
+            return True
+
+        with (
+            patch.object(client.rtp, "stop", side_effect=slow_stop),
+            patch.object(client.rtp, "start", side_effect=fake_start),
+        ):
+            await client._start_media()
+            first_owner = client._media_owner
+            client._end_call("local")
+            client._remote_rtp_ip = "203.0.113.8"
+            client._remote_rtp_port = 5004
+            await client._start_media()
+            await asyncio.sleep(0.05)
+        return order, client._media_active, first_owner, client._media_owner
+
+    order, active, first_owner, second_owner = asyncio.run(run())
+    assert order == ["start", "stop", "start"]
+    assert active is True
+    assert first_owner == 0
+    assert second_owner == 1
+
+
+def test_late_media_stop_does_not_kill_new_session():
+    """A delayed stop for call A must not tear down call B's RTP."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client._remote_rtp_ip = "198.51.100.10"
+        client._remote_rtp_port = 4000
+        stops: list[int] = []
+
+        async def track_stop():
+            stops.append(1)
+
+        async def fake_start(port):
+            return True
+
+        with (
+            patch.object(client.rtp, "stop", side_effect=track_stop),
+            patch.object(client.rtp, "start", side_effect=fake_start),
+        ):
+            await client._start_media()
+            old = client._media_session
+            client._media_session += 1
+            client._remote_rtp_ip = "203.0.113.8"
+            await client._start_media()
+            await client._stop_media_session(old)
+        return client._media_active, client._media_owner, stops
+
+    active, owner, stops = asyncio.run(run())
+    assert active is True
+    assert owner == 1
+    # First start has no prior session; second start stops leftover A, late
+    # stop_session(0) is a no-op so rtp.stop ran once.
+    assert stops == [1]
+
+
+def test_auto_answer_right_after_bye_starts_media():
+    """Intercom: BYE then a new auto-answer INVITE before stop finishes."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        client.registered = True
+        client.state = sip_client.SipState.REGISTERED
+        client._local_ip = "192.0.2.1"
+        client._local_port = 5060
+        starts: list[str] = []
+
+        async def slow_stop():
+            await asyncio.sleep(0.02)
+
+        async def fake_start(port):
+            starts.append(client._remote_rtp_ip)
+            return True
+
+        first = _invite_request(call_id="a@example", sdp_ip="198.51.100.10")
+        first.headers["call-info"] = "<sip:door>;answer-after=0"
+        second = _invite_request(
+            call_id="b@example", branch="z9hG4bKb", sdp_ip="203.0.113.8"
+        )
+        second.headers["call-info"] = "<sip:door>;answer-after=0"
+        bye = sm.parse_sip_message(
+            "BYE sip:alice@example SIP/2.0\r\n"
+            "Via: SIP/2.0/UDP pbx.example;branch=z9hG4bKbye\r\n"
+            "From: <sip:bob@example>;tag=remote\r\n"
+            "To: <sip:alice@example>;tag=placeholder\r\n"
+            "Call-ID: a@example\r\n"
+            "CSeq: 2 BYE\r\n"
+            "Content-Length: 0\r\n\r\n"
+        )
+        with (
+            patch.object(client, "_send_raw"),
+            patch.object(client.rtp, "stop", side_effect=slow_stop),
+            patch.object(client.rtp, "start", side_effect=fake_start),
+        ):
+            client._handle_request(first)
+            await asyncio.sleep(0.05)
+            bye.headers["to"] = client._d_local
+            client._handle_request(bye)
+            client._handle_request(second)
+            await asyncio.sleep(0.08)
+        return starts, client._media_active, client.state, client._remote_rtp_ip
+
+    starts, active, state, remote = asyncio.run(run())
+    assert starts == ["198.51.100.10", "203.0.113.8"]
+    assert active is True
+    assert state == sip_client.SipState.IN_CALL
+    assert remote == "203.0.113.8"
+
+
 def test_new_call_chooses_preferred_codec_not_previous():
     if sip_client is None:
         return


### PR DESCRIPTION
## Summary
- Guard `_start_media` / `_stop_media` with an `asyncio.Lock`. A start that still sees leftover media stops it first, then binds the new session.
- Tag each hangup with a media session id so a late `_stop_media` task cannot tear down the next call's RTP.
- Cover hangup-then-start, late stop, and BYE + auto-answer INVITE before stop finishes.

## Test plan
- [x] `python -m pytest tests/` (200 passed on Python 3.14, ~5s)
- [x] `ruff check custom_components/ tests/`
- [ ] Optional: two intercom auto-answer calls back-to-back and confirm the second has RTP (`call_audio` not `none`)


Made with [Cursor](https://cursor.com)