### PR TITLE
fix: close recordings on hangup and stop blocking RTP writes (P2-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,15 @@ Sends DTMF digits to the active SIP call.
 ### `sip.start_recording`
 Starts recording call audio to a local WAV file.
 - `entity_id` *(Required)*: The target SIP media player entity.
-- `recording_file` *(Required)*: Absolute path of the WAV file to save (e.g., `/media/recording.wav`).
+- `recording_file` *(Required)*: Path of the WAV file to save. Relative paths are resolved against the Home Assistant config directory (e.g. `www/sip/last_msg.wav`). Absolute paths must stay inside an allowed directory:
+  - the config directory
+  - `allowlist_external_dirs` and `media_dirs`
+  - Home Assistant OS `/media` and `/share` (when those mounts exist)
+
+Parent directories are created if missing. Hangup closes the file and fires `sip_recording_stopped`; you do not have to call `sip.stop_recording` first. A new recording never appends to a previous call's WAV.
 
 ### `sip.stop_recording`
-Stops active call recording.
+Stops active call recording and finalizes the WAV so it is immediately playable.
 - `entity_id` *(Required)*: The target SIP media player entity.
 
 ### `sip.start_assist`

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -47,8 +47,34 @@ from .const import (
 )
 from .helpers import get_ffmpeg_bin
 from .ivr import IvrSession
+from .recording import (
+    close_recorder_slot,
+    is_allowed_recording_path,
+    recording_allow_roots,
+    resolve_recording_path,
+)
 from .sip_client.audio import FfmpegAudioSource, NullSink
 from .sip_client.sip_client import SipCallbacks, SipClient, SipConfig, SipState
+
+
+def _recording_roots(hass: HomeAssistant) -> list[str]:
+    extra = list(hass.config.allowlist_external_dirs)
+    extra.extend(hass.config.media_dirs.values())
+    return recording_allow_roots(hass.config.path(), extra)
+
+
+def _fire_recording_stopped(hass: HomeAssistant, entry_id: str, data: dict) -> None:
+    stop_data = {"sip_account": data["config"].username}
+    device_id = _sip_device_id(hass, entry_id)
+    if device_id:
+        stop_data["device_id"] = device_id
+    hass.bus.async_fire(EVENT_SIP_RECORDING_STOPPED, stop_data)
+    async_dispatcher_send(
+        hass,
+        f"{DOMAIN}_event_{entry_id}",
+        EVENT_SIP_RECORDING_STOPPED,
+        None,
+    )
 
 
 def _sip_device_id(hass: HomeAssistant, entry_id: str) -> str | None:
@@ -342,7 +368,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if assist_bridge is not None:
             assist_bridge.close()
             assist_bridge = None
-            client.set_sink(NullSink())
+        recorder = close_recorder_slot(entry.runtime_data)
+        client.set_sink(NullSink())
+        if recorder is not None:
+            entry_id = entry.entry_id
+
+            async def _finish_recording() -> None:
+                await recorder.wait_closed()
+                _fire_recording_stopped(hass, entry_id, entry.runtime_data)
+
+            hass.async_create_task(_finish_recording())
         async_dispatcher_send(hass, f"{DOMAIN}_state_update_{entry.entry_id}")
 
     @callback
@@ -412,6 +447,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Handle clean shutdown
     async def shutdown(event) -> None:
+        recorder = close_recorder_slot(entry.runtime_data)
+        if recorder is not None:
+            client.set_sink(NullSink())
+            await recorder.wait_closed()
         await client.stop()
 
     entry.async_on_unload(
@@ -530,6 +569,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry_data = entry.runtime_data
     if entry_data:
         client: SipClient = entry_data["client"]
+        recorder = close_recorder_slot(entry_data)
+        if recorder is not None:
+            client.set_sink(NullSink())
+            await recorder.wait_closed()
         await client.stop()
         # Clean up tasks
         start_task: asyncio.Task = entry_data.get("start_task")
@@ -757,6 +800,9 @@ async def async_register_services(hass: HomeAssistant) -> None:
         from .sip_client.audio import WavRecorderSink
         import os
 
+        roots = _recording_roots(hass)
+        config_dir = hass.config.path()
+
         for entry_id, data in targets:
             client: SipClient = data["client"]
             target_file = recording_file
@@ -783,6 +829,24 @@ async def async_register_services(hass: HomeAssistant) -> None:
                 if data["config"].username not in target_file:
                     target_file = f"{base}_{data['config'].username}{ext}"
 
+            try:
+                target_file = resolve_recording_path(str(target_file), config_dir)
+            except ValueError:
+                LOGGER.error("Recording path is empty")
+                continue
+            if not is_allowed_recording_path(target_file, roots):
+                LOGGER.error(
+                    "Recording path %s is outside allowed directories "
+                    "(config dir, allowlist_external_dirs, media_dirs, /media, /share)",
+                    target_file,
+                )
+                continue
+
+            old = close_recorder_slot(data)
+            if old is not None:
+                client.set_sink(NullSink())
+                hass.async_create_task(old.wait_closed())
+
             recorder = WavRecorderSink(
                 target_file, sample_rate=client.codec.sample_rate
             )
@@ -807,24 +871,12 @@ async def async_register_services(hass: HomeAssistant) -> None:
         targets = await get_client_entries(call)
         for entry_id, data in targets:
             client: SipClient = data["client"]
-            recorder = data.get("recorder")
-            if recorder:
-                recorder.close()
-                from .sip_client.audio import NullSink
-
-                client.set_sink(NullSink())
-                data.pop("recorder")
-                stop_data = {"sip_account": data["config"].username}
-                device_id = _sip_device_id(hass, entry_id)
-                if device_id:
-                    stop_data["device_id"] = device_id
-                hass.bus.async_fire(EVENT_SIP_RECORDING_STOPPED, stop_data)
-                async_dispatcher_send(
-                    hass,
-                    f"{DOMAIN}_event_{entry_id}",
-                    EVENT_SIP_RECORDING_STOPPED,
-                    None,
-                )
+            recorder = close_recorder_slot(data)
+            if recorder is None:
+                continue
+            client.set_sink(NullSink())
+            await recorder.wait_closed()
+            _fire_recording_stopped(hass, entry_id, data)
 
     async def handle_start_assist(call: ServiceCall) -> None:
         targets = await get_client_entries(call)

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -845,7 +845,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
             old = close_recorder_slot(data)
             if old is not None:
                 client.set_sink(NullSink())
-                hass.async_create_task(old.wait_closed())
+                await old.wait_closed()
+                _fire_recording_stopped(hass, entry_id, data)
 
             recorder = WavRecorderSink(
                 target_file, sample_rate=client.codec.sample_rate

--- a/custom_components/sip/recording.py
+++ b/custom_components/sip/recording.py
@@ -1,0 +1,61 @@
+"""Call recording path policy and recorder-slot helpers.
+
+Kept free of Home Assistant imports so the SIP core tests can load it.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Home Assistant OS mounts that are not always in allowlist_external_dirs.
+HAOS_RECORDING_ROOTS = ("/media", "/share")
+
+
+def resolve_recording_path(raw: str, config_dir: str) -> str:
+    """Return an absolute recording path; relative names go under ``config_dir``."""
+    path = os.path.expanduser(str(raw).strip())
+    if not path:
+        raise ValueError("recording path is empty")
+    if not os.path.isabs(path):
+        path = os.path.join(config_dir, path)
+    return os.path.realpath(path)
+
+
+def is_allowed_recording_path(path: str, roots: list[str]) -> bool:
+    """True if ``path`` resolves inside one of ``roots``."""
+    try:
+        real = os.path.realpath(path)
+    except OSError:
+        return False
+    for root in roots:
+        try:
+            root_real = os.path.realpath(root)
+        except OSError:
+            continue
+        try:
+            if os.path.commonpath([root_real, real]) == root_real:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def recording_allow_roots(
+    config_dir: str, extra: list[str] | None = None
+) -> list[str]:
+    """Config dir, caller extras, and HA OS ``/media`` / ``/share`` when present."""
+    roots = [config_dir]
+    if extra:
+        roots.extend(extra)
+    for well_known in HAOS_RECORDING_ROOTS:
+        if os.path.isdir(well_known):
+            roots.append(well_known)
+    return roots
+
+
+def close_recorder_slot(data: dict[str, Any]) -> Any:
+    """Pop and close ``data['recorder']``. Returns the sink, or None."""
+    recorder = data.pop("recorder", None)
+    if recorder is not None:
+        recorder.close()
+    return recorder

--- a/custom_components/sip/sip_client/audio.py
+++ b/custom_components/sip/sip_client/audio.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import os
+import queue
 import struct
+import threading
 import wave
 from abc import ABC, abstractmethod
 from typing import Callable
@@ -98,23 +101,91 @@ class NullSink(AudioSink):
         self.bytes_received += len(pcm_le)
 
 
-class WavRecorderSink(AudioSink):
-    """Records received audio to a WAV file (handy for verifying the RX path)."""
+# ~5 s of 20 ms frames. Bound so a stalled disk cannot grow unbounded.
+_WAV_QUEUE_MAX_FRAMES = 250
 
-    def __init__(self, path: str, sample_rate: int = 8000) -> None:
-        self._wav = wave.open(path, "wb")
-        self._wav.setnchannels(1)
-        self._wav.setsampwidth(2)
-        self._wav.setframerate(sample_rate)
+
+class WavRecorderSink(AudioSink):
+    """Records received audio to a WAV file without blocking the RTP callback.
+
+    ``write`` only enqueues PCM. A worker thread opens the file, writes
+    frames, and closes the WAV so the event loop never waits on disk I/O.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        sample_rate: int = 8000,
+        *,
+        max_queued_frames: int = _WAV_QUEUE_MAX_FRAMES,
+    ) -> None:
+        self.path = path
+        self._sample_rate = sample_rate
+        self._queue: queue.Queue[bytes] = queue.Queue(maxsize=max_queued_frames)
+        self._stop = threading.Event()
+        self._done = threading.Event()
+        self._closed = False
+        self._dropped = False
+        self._thread = threading.Thread(
+            target=self._run, name="sip-wav-recorder", daemon=True
+        )
+        self._thread.start()
 
     def write(self, pcm_le: bytes) -> None:
-        self._wav.writeframes(pcm_le)
+        if self._closed or not pcm_le:
+            return
+        try:
+            self._queue.put_nowait(pcm_le)
+        except queue.Full:
+            if not self._dropped:
+                self._dropped = True
+                _LOGGER.warning(
+                    "Recording queue full; dropping incoming PCM (%s)", self.path
+                )
 
     def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stop.set()
+
+    async def wait_closed(self) -> None:
+        """Wait until queued PCM is flushed and the WAV header is finalized."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 10.0
+        while not self._done.is_set():
+            if loop.time() >= deadline:
+                _LOGGER.warning("Timed out waiting for WAV flush (%s)", self.path)
+                return
+            await asyncio.sleep(0.02)
+
+    def _run(self) -> None:
+        wav = None
         try:
-            self._wav.close()
+            parent = os.path.dirname(self.path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            wav = wave.open(self.path, "wb")
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(self._sample_rate)
+            while True:
+                try:
+                    chunk = self._queue.get(timeout=0.05)
+                except queue.Empty:
+                    if self._stop.is_set():
+                        break
+                    continue
+                wav.writeframes(chunk)
         except Exception:  # noqa: BLE001
-            pass
+            _LOGGER.exception("WAV recorder failed (%s)", self.path)
+        finally:
+            if wav is not None:
+                try:
+                    wav.close()
+                except Exception:  # noqa: BLE001
+                    pass
+            self._done.set()
 
 
 class _ConfiguredPcmSource(AudioSource):

--- a/custom_components/sip/strings.json
+++ b/custom_components/sip/strings.json
@@ -215,7 +215,7 @@
       "fields": {
         "recording_file": {
           "name": "Recording file path",
-          "description": "Absolute path of the WAV file to save (e.g. /media/recording.wav)."
+          "description": "Path of the WAV file. Relative paths are under the Home Assistant config directory. Must be inside an allowed directory (config, allowlist_external_dirs, /media, or /share)."
         }
       }
     },

--- a/custom_components/sip/translations/de.json
+++ b/custom_components/sip/translations/de.json
@@ -215,7 +215,7 @@
       "fields": {
         "recording_file": {
           "name": "Aufnahmedateipfad",
-          "description": "Absoluter Pfad der zu speichernden WAV-Datei (z.B. /media/recording.wav)."
+          "description": "Pfad der WAV-Datei. Relative Pfade gelten ab dem Home-Assistant-Konfigurationsverzeichnis. Muss in einem erlaubten Verzeichnis liegen (Config, allowlist_external_dirs, /media oder /share)."
         }
       }
     },

--- a/custom_components/sip/translations/en.json
+++ b/custom_components/sip/translations/en.json
@@ -215,7 +215,7 @@
       "fields": {
         "recording_file": {
           "name": "Recording file path",
-          "description": "Absolute path of the WAV file to save (e.g. /media/recording.wav)."
+          "description": "Path of the WAV file. Relative paths are under the Home Assistant config directory. Must be inside an allowed directory (config, allowlist_external_dirs, /media, or /share)."
         }
       }
     },

--- a/custom_components/sip/translations/ko.json
+++ b/custom_components/sip/translations/ko.json
@@ -215,7 +215,7 @@
       "fields": {
         "recording_file": {
           "name": "녹음 파일 경로",
-          "description": "저장할 WAV 파일의 절대 경로 (예: /media/recording.wav)."
+          "description": "WAV 파일 경로. 상대 경로는 Home Assistant 설정 디렉터리 기준입니다. 허용된 디렉터리(설정 폴더, allowlist_external_dirs, /media, /share) 안에 있어야 합니다."
         }
       }
     },

--- a/custom_components/sip/translations/ru.json
+++ b/custom_components/sip/translations/ru.json
@@ -215,7 +215,7 @@
       "fields": {
         "recording_file": {
           "name": "Путь к файлу записи",
-          "description": "Абсолютный путь к сохраняемому WAV-файлу (например, /media/recording.wav)."
+          "description": "Путь к WAV-файлу. Относительные пути считаются от каталога конфигурации Home Assistant. Должен быть внутри разрешённого каталога (config, allowlist_external_dirs, /media или /share)."
         }
       }
     },

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -520,19 +520,26 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 ---
 
-### [ ] P2-2. 녹음 정리 + 블로킹 I/O 제거
+### [x] P2-2. 녹음 정리 + 블로킹 I/O 제거
 
 **작업**
-1. `on_call_ended`(`__init__.py:278`)에서 recorder를 닫고 sink를 `NullSink`로 되돌리며
+1. `on_call_ended`에서 recorder를 닫고 sink를 `NullSink`로 되돌리며
    `data["recorder"]`를 제거한다. `EVENT_SIP_RECORDING_STOPPED`도 발행한다.
-2. `WavRecorderSink`(`audio.py:101`)를 비블로킹으로 바꾼다. RTP 콜백에서는 큐에 넣고,
-   별도 태스크/executor가 디스크에 쓴다. `wave.open`도 executor로 옮긴다.
-3. 파일 경로 검증: HA 설정 디렉터리 밖 임의 경로 쓰기를 막을지 결정하고 문서화한다.
+2. `WavRecorderSink`를 비블로킹으로 바꾼다. RTP 콜백에서는 큐에 넣고,
+   워커 스레드가 디스크에 쓴다. `wave.open`도 워커에서 호출한다.
+3. 녹음 경로는 설정 디렉터리 / `allowlist_external_dirs` / `media_dirs` /
+   HA OS `/media`·`/share` 안으로 제한한다. 상대 경로는 설정 디렉터리 기준.
 
 **수용 기준**
 - 통화 종료 시 WAV 파일이 닫히고 재생 가능한 상태가 된다.
 - 연속 두 통화를 녹음하면 서로 다른 파일에 기록된다(같은 파일에 이어 쓰지 않는다).
 - RTP 콜백 경로에 파일 I/O가 없다.
+
+**추가된 테스트**
+- `test_wav_recorder_write_does_not_block_on_open`
+- `test_wav_recorder_close_finalizes_playable_wav`
+- `test_wav_recorder_consecutive_calls_do_not_append`
+- `test_recording_path_rejects_escape_from_config_dir`
 
 ---
 

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,0 +1,163 @@
+"""Call recording close, non-blocking WAV I/O, and path policy (P2-2)."""
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import threading
+import time
+import wave
+from unittest.mock import MagicMock, patch
+
+from test_pure import _load_component_module, audio
+
+recording = _load_component_module("recording")
+
+
+def test_resolve_recording_path_joins_relative_to_config_dir():
+    with tempfile.TemporaryDirectory() as config_dir:
+        resolved = recording.resolve_recording_path("www/rec.wav", config_dir)
+        assert resolved == os.path.realpath(os.path.join(config_dir, "www/rec.wav"))
+
+
+def test_resolve_recording_path_keeps_absolute():
+    with tempfile.TemporaryDirectory() as tmp:
+        raw = os.path.join(tmp, "out.wav")
+        assert recording.resolve_recording_path(raw, "/unused") == os.path.realpath(raw)
+
+
+def test_resolve_recording_path_rejects_empty():
+    try:
+        recording.resolve_recording_path("  ", "/config")
+    except ValueError:
+        return
+    raise AssertionError("empty path must raise")
+
+
+def test_recording_path_rejects_escape_from_config_dir():
+    with tempfile.TemporaryDirectory() as config_dir:
+        escaped = recording.resolve_recording_path("../secret.wav", config_dir)
+        assert recording.is_allowed_recording_path(escaped, [config_dir]) is False
+        inside = recording.resolve_recording_path("ok.wav", config_dir)
+        assert recording.is_allowed_recording_path(inside, [config_dir]) is True
+
+
+def test_close_recorder_slot_closes_and_clears():
+    sink = MagicMock()
+    data = {"recorder": sink, "other": 1}
+    assert recording.close_recorder_slot(data) is sink
+    sink.close.assert_called_once()
+    assert "recorder" not in data
+    assert recording.close_recorder_slot(data) is None
+
+
+def test_wav_recorder_write_does_not_block_on_open():
+    """wave.open lives on the worker thread; write() must not wait for it."""
+    if audio is None:
+        return
+    opened = threading.Event()
+    proceed = threading.Event()
+    real_open = wave.open
+
+    def slow_open(*args, **kwargs):
+        opened.set()
+        proceed.wait(timeout=2)
+        return real_open(*args, **kwargs)
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "rec.wav")
+            with patch.object(wave, "open", side_effect=slow_open):
+                t0 = time.monotonic()
+                sink = audio.WavRecorderSink(path)
+                assert time.monotonic() - t0 < 0.2
+                assert opened.wait(timeout=1)
+                t1 = time.monotonic()
+                sink.write(b"\x00" * 320)
+                assert time.monotonic() - t1 < 0.05
+                proceed.set()
+                sink.close()
+                await sink.wait_closed()
+
+    asyncio.run(run())
+
+
+def test_wav_recorder_close_finalizes_playable_wav():
+    if audio is None:
+        return
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "rec.wav")
+            sink = audio.WavRecorderSink(path, sample_rate=8000)
+            pcm = b"\x00\x01" * 160
+            sink.write(pcm)
+            sink.close()
+            await sink.wait_closed()
+            with wave.open(path, "rb") as wav:
+                assert wav.getnchannels() == 1
+                assert wav.getsampwidth() == 2
+                assert wav.getframerate() == 8000
+                assert wav.readframes(wav.getnframes()) == pcm
+
+    asyncio.run(run())
+
+
+def test_wav_recorder_consecutive_calls_do_not_append():
+    """Hangup must close the WAV so the next call cannot extend the same file."""
+    if audio is None:
+        return
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp:
+            path_a = os.path.join(tmp, "a.wav")
+            path_b = os.path.join(tmp, "b.wav")
+            same = os.path.join(tmp, "same.wav")
+            first = b"\x11" * 320
+            second = b"\x22" * 640
+
+            sink = audio.WavRecorderSink(path_a, sample_rate=8000)
+            sink.write(first)
+            sink.close()
+            await sink.wait_closed()
+
+            sink = audio.WavRecorderSink(path_b, sample_rate=8000)
+            sink.write(second)
+            sink.close()
+            await sink.wait_closed()
+
+            with wave.open(path_a, "rb") as wav:
+                assert wav.readframes(wav.getnframes()) == first
+            with wave.open(path_b, "rb") as wav:
+                assert wav.readframes(wav.getnframes()) == second
+
+            sink = audio.WavRecorderSink(same, sample_rate=8000)
+            sink.write(first)
+            sink.close()
+            await sink.wait_closed()
+            sink = audio.WavRecorderSink(same, sample_rate=8000)
+            sink.write(second)
+            sink.close()
+            await sink.wait_closed()
+            with wave.open(same, "rb") as wav:
+                data = wav.readframes(wav.getnframes())
+            assert data == second
+            assert len(data) != len(first) + len(second)
+
+    asyncio.run(run())
+
+
+def test_wav_recorder_creates_parent_directory():
+    if audio is None:
+        return
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "nested", "rec.wav")
+            sink = audio.WavRecorderSink(path, sample_rate=8000)
+            sink.write(b"\x00" * 320)
+            sink.close()
+            await sink.wait_closed()
+            assert os.path.isfile(path)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Hangup / unload / HA stop close the active recorder, restore `NullSink`, and fire `sip_recording_stopped` after the WAV header is finalized so the next call cannot append to an open file.
- `WavRecorderSink.write` only enqueues PCM; a worker thread owns `wave.open` / `writeframes` / `close`, so the RTP callback no longer does disk I/O.
- Recording paths are resolved relative to the config dir and must stay under the config dir, `allowlist_external_dirs`, `media_dirs`, or HA OS `/media` and `/share`.

## Test plan
- [ ] `sip.start_recording` during a call, hang up without `sip.stop_recording` — WAV is closed and playable; `sip_recording_stopped` fires.
- [ ] Record two consecutive calls (same or different paths) — second file is not an append of the first.
- [ ] Relative path like `www/sip/last.wav` writes under the config directory; a path that escapes the config dir is rejected.
- [ ] `ruff check custom_components/ tests/` and `pytest tests/` (211 passed locally).


Made with [Cursor](https://cursor.com)