### PR TITLE
feat: fan out RTP RX so Assist and recording can run together (P2-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Sends DTMF digits to the active SIP call.
 > **Inbound DTMF:** digits pressed by the remote party are accepted both as RFC 2833 / RFC 4733 telephone-event packets and as SIP INFO (`application/dtmf-relay`), which is what many ATA/VoIP adapters send. **In-band DTMF (audio tones) is not detected** — set your ATA or PBX to RFC 2833 or SIP INFO if key presses are not recognised.
 
 ### `sip.start_recording`
-Starts recording call audio to a local WAV file.
+Starts recording call audio to a local WAV file. Can run at the same time as `sip.start_assist` — received audio is copied to both the WAV file and the Assist pipeline, and stopping one does not mute the other.
 - `entity_id` *(Required)*: The target SIP media player entity.
 - `recording_file` *(Required)*: Path of the WAV file to save. Relative paths are resolved against the Home Assistant config directory (e.g. `www/sip/last_msg.wav`). Absolute paths must stay inside an allowed directory:
   - the config directory

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -53,7 +53,7 @@ from .recording import (
     recording_allow_roots,
     resolve_recording_path,
 )
-from .sip_client.audio import FfmpegAudioSource, NullSink
+from .sip_client.audio import FfmpegAudioSource
 from .sip_client.sip_client import SipCallbacks, SipClient, SipConfig, SipState
 
 
@@ -369,7 +369,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             assist_bridge.close()
             assist_bridge = None
         recorder = close_recorder_slot(entry.runtime_data)
-        client.set_sink(NullSink())
+        client.clear_sinks()
         if recorder is not None:
             entry_id = entry.entry_id
 
@@ -448,8 +448,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Handle clean shutdown
     async def shutdown(event) -> None:
         recorder = close_recorder_slot(entry.runtime_data)
+        client.clear_sinks()
         if recorder is not None:
-            client.set_sink(NullSink())
             await recorder.wait_closed()
         await client.stop()
 
@@ -501,6 +501,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ) -> None:
         nonlocal assist_bridge
         if assist_bridge is not None:
+            client.remove_sink(assist_bridge)
             assist_bridge.close()
 
         bridge = AssistBridge(
@@ -528,14 +529,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if assist_bridge is not bridge:
                 return
             LOGGER.info("Assist pipeline bridge finished")
-            client.set_sink(NullSink())
+            client.remove_sink(bridge)
             assist_bridge = None
             if hangup_on_end:
                 client.hangup()
 
         bridge.on_done = on_assist_done
         assist_bridge = bridge
-        client.set_sink(assist_bridge)
+        client.add_sink(assist_bridge)
         assist_bridge.start()
 
     # Keep a dict of active IVR/Assist objects we can update
@@ -570,8 +571,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry_data:
         client: SipClient = entry_data["client"]
         recorder = close_recorder_slot(entry_data)
+        client.clear_sinks()
         if recorder is not None:
-            client.set_sink(NullSink())
             await recorder.wait_closed()
         await client.stop()
         # Clean up tasks
@@ -844,14 +845,14 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
             old = close_recorder_slot(data)
             if old is not None:
-                client.set_sink(NullSink())
+                client.remove_sink(old)
                 await old.wait_closed()
                 _fire_recording_stopped(hass, entry_id, data)
 
             recorder = WavRecorderSink(
                 target_file, sample_rate=client.codec.sample_rate
             )
-            client.set_sink(recorder)
+            client.add_sink(recorder)
             data["recorder"] = recorder
             rec_data = {
                 "sip_account": data["config"].username,
@@ -875,7 +876,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
             recorder = close_recorder_slot(data)
             if recorder is None:
                 continue
-            client.set_sink(NullSink())
+            client.remove_sink(recorder)
             await recorder.wait_closed()
             _fire_recording_stopped(hass, entry_id, data)
 

--- a/custom_components/sip/sip_client/audio.py
+++ b/custom_components/sip/sip_client/audio.py
@@ -6,8 +6,9 @@ This is the extension seam. The SIP/RTP core only knows about two PCM ports:
 * :class:`AudioSink` receives RX audio from ``RtpSession.on_audio``.
 
 Today's implementations cover "play a file / TTS to the far end" (TX) and
-"discard / record" (RX). A microphone source or a media_player sink can be added
-later by implementing the same tiny interfaces, without touching the SIP core.
+"discard / record / tee to several listeners" (RX). A microphone source or a
+media_player sink can be added later by implementing the same tiny interfaces,
+without touching the SIP core.
 """
 from __future__ import annotations
 
@@ -99,6 +100,47 @@ class NullSink(AudioSink):
 
     def write(self, pcm_le: bytes) -> None:
         self.bytes_received += len(pcm_le)
+
+
+class TeeSink(AudioSink):
+    """Fan-out PCM to registered sinks; one failure does not stop the others."""
+
+    def __init__(self, *sinks: AudioSink) -> None:
+        self._sinks: list[AudioSink] = []
+        for sink in sinks:
+            self.add(sink)
+
+    def add(self, sink: AudioSink) -> None:
+        if sink is self or sink in self._sinks:
+            return
+        self._sinks.append(sink)
+
+    def remove(self, sink: AudioSink) -> None:
+        try:
+            self._sinks.remove(sink)
+        except ValueError:
+            pass
+
+    def clear(self) -> None:
+        self._sinks.clear()
+
+    @property
+    def sinks(self) -> tuple[AudioSink, ...]:
+        return tuple(self._sinks)
+
+    def write(self, pcm_le: bytes) -> None:
+        for sink in list(self._sinks):
+            try:
+                sink.write(pcm_le)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Audio sink error")
+
+    def close(self) -> None:
+        for sink in list(self._sinks):
+            try:
+                sink.close()
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Audio sink close error")
 
 
 # ~5 s of 20 ms frames. Bound so a stalled disk cannot grow unbounded.

--- a/custom_components/sip/sip_client/sip_client.py
+++ b/custom_components/sip/sip_client/sip_client.py
@@ -18,7 +18,7 @@ from typing import Callable
 from . import codecs
 from . import sip_message as sm
 from . import trace
-from .audio import AudioSink, AudioSource, NullSink
+from .audio import AudioSink, AudioSource, NullSink, TeeSink
 from .rtp_session import RtpSession
 from .sip_auth import digest_response
 
@@ -288,7 +288,7 @@ class SipClient:
         self.rtp = RtpSession()
         self.rtp.media_timeout = float(self.config.media_timeout)
         self.rtp.on_media_timeout = self._on_media_timeout
-        self.sink: AudioSink = NullSink()
+        self.sink: AudioSink = TeeSink()
         self._tx_source_task: asyncio.Task | None = None
         self._pending_source: AudioSource | None = None
         self._ring_timeout_handle: asyncio.TimerHandle | None = None
@@ -314,8 +314,32 @@ class SipClient:
     def media_playing(self) -> bool:
         return self._tx_source_task is not None and not self._tx_source_task.done()
 
+    def add_sink(self, sink: AudioSink) -> None:
+        """Register an RX listener without replacing the others."""
+        if not isinstance(self.sink, TeeSink):
+            self.sink = TeeSink(self.sink)
+        self.sink.add(sink)
+
+    def remove_sink(self, sink: AudioSink) -> None:
+        """Unregister one RX listener; remaining sinks keep receiving."""
+        if isinstance(self.sink, TeeSink):
+            self.sink.remove(sink)
+            return
+        if self.sink is sink:
+            self.sink = TeeSink()
+
+    def clear_sinks(self) -> None:
+        """Drop every RX listener (call end / shutdown). Does not close them."""
+        if isinstance(self.sink, TeeSink):
+            self.sink.clear()
+        else:
+            self.sink = TeeSink()
+
     def set_sink(self, sink: AudioSink) -> None:
-        self.sink = sink
+        """Replace the sink chain with ``sink`` (``NullSink`` clears it)."""
+        self.clear_sinks()
+        if not isinstance(sink, NullSink):
+            self.add_sink(sink)
 
     def diagnostics_snapshot(self) -> dict:
         """Runtime SIP/RTP state for the HA diagnostics download (no secrets)."""

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -543,7 +543,7 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 ---
 
-### [ ] P2-3. tee sink (녹음 + Assist 동시)
+### [x] P2-3. tee sink (녹음 + Assist 동시)
 
 **작업** 여러 `AudioSink`에 PCM을 분배하는 `TeeSink`를 `audio.py`에 추가하고,
 `set_sink` 단일 슬롯 대신 sink 등록/해제 구조로 바꾼다. 한 sink의 예외가 다른 sink를
@@ -551,6 +551,12 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 **수용 기준** Assist 세션 중 `sip.start_recording`을 호출해도 Assist가 계속 듣고,
 녹음 파일에도 음성이 기록된다.
+
+**추가된 테스트**
+- `test_tee_sink_fans_out_to_every_listener`
+- `test_tee_sink_isolates_listener_errors`
+- `test_start_recording_during_assist_keeps_both_sinks`
+- `test_stop_recording_does_not_detach_assist`
 
 ---
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -4099,14 +4099,14 @@ def test_assist_preroll_injected_into_stream():
 
 
 def test_assist_done_guard_skips_superseded_bridge():
-    """Regression: superseded bridge on_done must not clobber the active sink."""
-    state = {"assist_bridge": None, "sink": None}
+    """Regression: superseded bridge on_done must not detach the active assist."""
+    state = {"assist_bridge": None, "sinks": set()}
 
     def make_on_done(bridge):
         def on_assist_done() -> None:
             if state["assist_bridge"] is not bridge:
                 return
-            state["sink"] = "null"
+            state["sinks"].discard(bridge)
             state["assist_bridge"] = None
 
         return on_assist_done
@@ -4114,24 +4114,24 @@ def test_assist_done_guard_skips_superseded_bridge():
     bridge_a = object()
     bridge_b = object()
     state["assist_bridge"] = bridge_b
-    state["sink"] = "bridge_b"
+    state["sinks"] = {bridge_b, "recorder"}
     make_on_done(bridge_a)()
     assert state["assist_bridge"] is bridge_b
-    assert state["sink"] == "bridge_b"
+    assert state["sinks"] == {bridge_b, "recorder"}
 
 
-def test_call_ended_restores_sink_when_assist_bridge_cleared():
-    """Regression: call end must restore sink even if on_assist_done guard no-ops."""
-    state = {"assist_bridge": object(), "sink": "bridge"}
+def test_call_ended_clears_sinks_when_assist_bridge_cleared():
+    """Regression: call end must drop every sink even if on_assist_done guard no-ops."""
+    state = {"assist_bridge": object(), "sinks": {"bridge", "recorder"}}
 
     def on_call_ended() -> None:
         if state["assist_bridge"] is not None:
             state["assist_bridge"] = None
-            state["sink"] = "null"
+        state["sinks"].clear()
 
     on_call_ended()
     assert state["assist_bridge"] is None
-    assert state["sink"] == "null"
+    assert state["sinks"] == set()
 
 
 def _run_one_turn(assist_mod, mock_ap, PET, PE, **bridge_kwargs):

--- a/tests/test_tee_sink.py
+++ b/tests/test_tee_sink.py
@@ -1,0 +1,109 @@
+"""TeeSink fan-out so Assist and recording can share RTP RX (P2-3)."""
+from __future__ import annotations
+
+import asyncio
+
+from test_pure import audio, sip_client
+
+
+class _ListSink(audio.AudioSink):
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, pcm_le: bytes) -> None:
+        self.chunks.append(pcm_le)
+
+
+class _BoomSink(audio.AudioSink):
+    def write(self, pcm_le: bytes) -> None:
+        raise RuntimeError("sink exploded")
+
+
+def test_tee_sink_fans_out_to_every_listener():
+    a = _ListSink()
+    b = _ListSink()
+    tee = audio.TeeSink(a, b)
+    tee.write(b"\x01\x02")
+    assert a.chunks == [b"\x01\x02"]
+    assert b.chunks == [b"\x01\x02"]
+
+
+def test_tee_sink_isolates_listener_errors():
+    boom = _BoomSink()
+    ok = _ListSink()
+    tee = audio.TeeSink(boom, ok)
+    tee.write(b"\x03")
+    assert ok.chunks == [b"\x03"]
+
+
+def test_tee_sink_add_remove_does_not_duplicate():
+    a = _ListSink()
+    tee = audio.TeeSink()
+    tee.add(a)
+    tee.add(a)
+    tee.write(b"x")
+    assert a.chunks == [b"x"]
+    tee.remove(a)
+    tee.write(b"y")
+    assert a.chunks == [b"x"]
+    tee.remove(a)  # missing is a no-op
+
+
+def test_start_recording_during_assist_keeps_both_sinks():
+    """Acceptance: Assist stays subscribed when a recorder is added."""
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        assist = _ListSink()
+        recorder = _ListSink()
+        client.add_sink(assist)
+        client._on_rx_audio(b"pre")
+        client.add_sink(recorder)
+        client._on_rx_audio(b"both")
+        client.remove_sink(assist)
+        client._on_rx_audio(b"post")
+        return assist.chunks, recorder.chunks
+
+    assist_chunks, recorder_chunks = asyncio.run(run())
+    assert assist_chunks == [b"pre", b"both"]
+    assert recorder_chunks == [b"both", b"post"]
+
+
+def test_stop_recording_does_not_detach_assist():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        assist = _ListSink()
+        recorder = _ListSink()
+        client.add_sink(assist)
+        client.add_sink(recorder)
+        client.remove_sink(recorder)
+        client._on_rx_audio(b"keep")
+        return assist.chunks, recorder.chunks
+
+    assist_chunks, recorder_chunks = asyncio.run(run())
+    assert assist_chunks == [b"keep"]
+    assert recorder_chunks == []
+
+
+def test_clear_sinks_drops_every_listener():
+    if sip_client is None:
+        return
+
+    async def run():
+        client = sip_client.SipClient(sip_client.SipConfig(server="pbx.example"))
+        a = _ListSink()
+        b = _ListSink()
+        client.add_sink(a)
+        client.add_sink(b)
+        client.clear_sinks()
+        client._on_rx_audio(b"gone")
+        return a.chunks, b.chunks
+
+    a_chunks, b_chunks = asyncio.run(run())
+    assert a_chunks == []
+    assert b_chunks == []


### PR DESCRIPTION
## Summary
- Add `TeeSink` so RTP RX PCM is copied to every registered listener; one sink exception does not stop the others.
- `SipClient` now has `add_sink` / `remove_sink` / `clear_sinks`. Assist and recording subscribe independently, so `sip.start_recording` during an Assist session no longer replaces the Assist sink.
- Hangup still `clear_sinks()` after closing the recorder and Assist bridge.

## Test plan
- [ ] Start Assist, then `sip.start_recording` mid-session — Assist keeps hearing and the WAV gets audio.
- [ ] `sip.stop_recording` while Assist is running — Assist continues; hangup still stops both.
- [ ] `ruff check custom_components/ tests/` and `pytest tests/` (217 passed locally).


Made with [Cursor](https://cursor.com)