### PR TITLE
feat: restore DND across Home Assistant restarts (P2-5)

### DIFF
--- a/custom_components/sip/dnd.py
+++ b/custom_components/sip/dnd.py
@@ -1,0 +1,16 @@
+"""DND restore mapping. Kept free of Home Assistant imports."""
+from __future__ import annotations
+
+
+def restored_dnd_enabled(state: str | None) -> bool | None:
+    """Map last HA switch state to DND. None means leave the client unchanged."""
+    if state in (None, "unknown", "unavailable"):
+        return None
+    return state == "on"
+
+
+def apply_restored_dnd(client, state: str | None) -> None:
+    """Copy a restored switch state onto ``client.dnd`` when it is definitive."""
+    enabled = restored_dnd_enabled(state)
+    if enabled is not None:
+        client.dnd = enabled

--- a/custom_components/sip/switch.py
+++ b/custom_components/sip/switch.py
@@ -7,7 +7,9 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
+from .dnd import apply_restored_dnd
 from .helpers import build_device_info
 from .sip_client.sip_client import SipClient
 
@@ -22,7 +24,7 @@ async def async_setup_entry(
     async_add_entities([SipDndSwitch(entry, entry_data)])
 
 
-class SipDndSwitch(SwitchEntity):
+class SipDndSwitch(SwitchEntity, RestoreEntity):
     """Representation of a DND switch for the SIP client."""
 
     _attr_has_entity_name = True
@@ -36,6 +38,11 @@ class SipDndSwitch(SwitchEntity):
         self._attr_unique_id = f"{entry.entry_id}_dnd"
         self._attr_translation_key = "dnd"
         self._attr_device_info = build_device_info(entry, self._config)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_state()
+        apply_restored_dnd(self._client, None if last is None else last.state)
 
     @property
     def icon(self) -> str:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -580,11 +580,17 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 ---
 
-### [ ] P2-5. DND 상태 복원
+### [x] P2-5. DND 상태 복원
 
 **작업** `SipDndSwitch`를 `RestoreEntity`로 바꿔 HA 재시작 후 DND 상태를 유지한다.
 
 **수용 기준** DND를 켠 뒤 HA를 재시작해도 켜진 상태로 복원된다.
+
+**추가된 테스트**
+- `test_restored_dnd_enabled_mapping`
+- `test_dnd_switch_restores_on_from_last_state`
+- `test_dnd_switch_restores_off_over_live_default`
+- `test_dnd_switch_keeps_default_when_no_last_state`
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,16 @@ class MockBase:
     def __class_getitem__(cls, item):
         return cls
 
+    async def async_added_to_hass(self):
+        return None
+
+
+class MockRestoreEntity:
+    """Separate base so SwitchEntity + RestoreEntity is a valid MRO."""
+
+    async def async_added_to_hass(self):
+        return None
+
 
 def mock_callback(func):
     """Mock for homeassistant.core.callback decorator."""
@@ -47,6 +57,8 @@ for mod in [
     "homeassistant.helpers.entity_registry",
     "homeassistant.helpers.dispatcher",
     "homeassistant.helpers.event",
+    "homeassistant.helpers.restore_state",
+    "homeassistant.helpers.entity_platform",
     "homeassistant.components",
     "homeassistant.components.websocket_api",
     "homeassistant.components.sensor",
@@ -59,3 +71,6 @@ for mod in [
     "homeassistant.util.dt",
 ]:
     sys.modules[mod] = MagicMock()
+
+sys.modules["homeassistant.helpers.restore_state"].RestoreEntity = MockRestoreEntity
+sys.modules["homeassistant.components.switch"].SwitchEntity = MockBase

--- a/tests/test_dnd_restore.py
+++ b/tests/test_dnd_restore.py
@@ -1,0 +1,39 @@
+"""DND switch restores on/off across Home Assistant restarts (P2-5)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from test_pure import _load_component_module
+
+dnd = _load_component_module("dnd")
+
+
+def test_restored_dnd_enabled_mapping():
+    assert dnd.restored_dnd_enabled("on") is True
+    assert dnd.restored_dnd_enabled("off") is False
+    assert dnd.restored_dnd_enabled(None) is None
+    assert dnd.restored_dnd_enabled("unknown") is None
+    assert dnd.restored_dnd_enabled("unavailable") is None
+
+
+def test_dnd_switch_restores_on_from_last_state():
+    client = MagicMock()
+    client.dnd = False
+    dnd.apply_restored_dnd(client, "on")
+    assert client.dnd is True
+
+
+def test_dnd_switch_restores_off_over_live_default():
+    client = MagicMock()
+    client.dnd = True
+    dnd.apply_restored_dnd(client, "off")
+    assert client.dnd is False
+
+
+def test_dnd_switch_keeps_default_when_no_last_state():
+    client = MagicMock()
+    client.dnd = False
+    dnd.apply_restored_dnd(client, None)
+    assert client.dnd is False
+    dnd.apply_restored_dnd(client, "unknown")
+    assert client.dnd is False


### PR DESCRIPTION
## Summary
- `SipDndSwitch` is a `RestoreEntity`. After HA restarts, last `on`/`off` is copied back onto `client.dnd` so incoming calls stay blocked.
- `unknown` / `unavailable` last states do not change the default (DND off).
- Mapping lives in HA-free `dnd.py` so SIP core tests can lock the restore rules.

## Test plan
- [ ] Turn DND on, restart Home Assistant, confirm the switch is still on and an inbound INVITE is rejected with 486.
- [ ] Turn DND off, restart, confirm inbound calls ring again.
- [ ] `ruff check custom_components/ tests/` and `pytest tests/` (225 passed locally).


Made with [Cursor](https://cursor.com)