### PR TITLE
feat: start Assist TTS playback before the stream finishes (P3-1)

### DIFF
--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -590,23 +590,44 @@ class AssistBridge(AudioSink):
             LOGGER.error("Assist pipeline error: %s", event.data)
 
     async def _play_tts_stream(self, stream: tts.ResultStream, epoch: int) -> None:
-        """Fetch TTS stream WAV output and play it to the SIP caller."""
+        """Play TTS into RTP as soon as the first audio chunk arrives.
+
+        Later chunks are fed to ffmpeg stdin while PCM is already going out,
+        so the far end does not wait for the whole synthesis to finish.
+        """
         try:
-            chunks = []
-            async for chunk in stream.async_stream_result():
-                if epoch != self._tts_epoch:
-                    return
-                chunks.append(chunk)
+            agen = stream.async_stream_result()
+            try:
+                first = await anext(agen)
+            except StopAsyncIteration:
+                if epoch == self._tts_epoch:
+                    self._tx_done.set()
+                return
             if epoch != self._tts_epoch:
+                aclose = getattr(agen, "aclose", None)
+                if callable(aclose):
+                    await aclose()
                 return
 
-            wav_data = b"".join(chunks)
-            source = FfmpegAudioSource(data=wav_data, ffmpeg_bin=get_ffmpeg_bin(self.hass))
+            async def chunks() -> AsyncIterable[bytes]:
+                if first:
+                    yield first
+                async for chunk in agen:
+                    if epoch != self._tts_epoch:
+                        return
+                    if chunk:
+                        yield chunk
+
             await self._wait_for_tx_idle()
             if epoch != self._tts_epoch:
                 return
+            source = FfmpegAudioSource(
+                chunks=chunks(), ffmpeg_bin=get_ffmpeg_bin(self.hass)
+            )
             self.play_source(source)
             self._tx_wait = "tts"
+        except asyncio.CancelledError:
+            raise
         except Exception as err:
             LOGGER.exception("Error playing Assist TTS response: %s", err)
             if epoch == self._tts_epoch:

--- a/custom_components/sip/sip_client/audio.py
+++ b/custom_components/sip/sip_client/audio.py
@@ -33,6 +33,10 @@ ActiveFn = Callable[[], bool]
 # one second and drops from the *front* when it overflows, so staying well
 # under that turns event-loop jitter into slack instead of dropped audio.
 _PCM_PREBUFFER_SEC = 0.5
+# How far behind real time is still treated as catch-up rather than a stall
+# that needs a clock resync. Paired with the prebuffer this is the most PCM
+# a source may dump in one burst (0.5 + 0.5 = 1.0 s), matching the TX cap.
+_PCM_MAX_BEHIND_SEC = _PCM_PREBUFFER_SEC
 
 
 def default_pcm_frame_bytes(sample_rate: int) -> int:
@@ -63,11 +67,19 @@ class _RealtimePacer:
 
     async def wait(self) -> None:
         ahead = self._queued_sec - (self._loop.time() - self._start)
+        if ahead < -_PCM_MAX_BEHIND_SEC:
+            # Streaming TTS (and a long loop freeze) can stall ffmpeg stdout
+            # for well over a second, then dump a blob. Unlimited catch-up
+            # would overflow RtpSession's 1 s TX buffer and clip speech.
+            # Slide the deadline so the next burst fills at most
+            # prebuffer+behind = 1.0 s; the rest is paced.
+            self._start = self._loop.time() - self._queued_sec - _PCM_MAX_BEHIND_SEC
+            ahead = -_PCM_MAX_BEHIND_SEC
         if ahead > _PCM_PREBUFFER_SEC:
             await asyncio.sleep(ahead - _PCM_PREBUFFER_SEC)
         else:
-            # Inside the prebuffer window (or behind it): yield without
-            # stalling so a delayed loop can catch back up to real time.
+            # Inside the prebuffer window (or a little behind it): yield
+            # without stalling so ordinary jitter can catch back up.
             await asyncio.sleep(0)
 
 

--- a/custom_components/sip/sip_client/audio.py
+++ b/custom_components/sip/sip_client/audio.py
@@ -21,6 +21,7 @@ import struct
 import threading
 import wave
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterable
 from typing import Callable
 
 _LOGGER = logging.getLogger(__name__)
@@ -275,6 +276,10 @@ class FfmpegAudioSource(_ConfiguredPcmSource):
 
     ``sample_rate`` / ``pcm_frame_bytes`` default to G.711 (8 kHz / 320 B). Call
     :meth:`configure` after negotiation when a different rate is active.
+
+    Provide exactly one of ``url``, ``data``, or ``chunks``. ``chunks`` is the
+    streaming-stdin mode: bytes are written to ffmpeg as they arrive so the
+    first PCM can leave before the producer has finished.
     """
 
     def __init__(
@@ -283,18 +288,22 @@ class FfmpegAudioSource(_ConfiguredPcmSource):
         *,
         url: str | None = None,
         data: bytes | None = None,
+        chunks: AsyncIterable[bytes] | None = None,
         sample_rate: int = 8000,
         pcm_frame_bytes: int | None = None,
     ) -> None:
         super().__init__(sample_rate=sample_rate, pcm_frame_bytes=pcm_frame_bytes)
-        if (url is None) == (data is None):
-            raise ValueError("Provide exactly one of url/data")
+        provided = sum(v is not None for v in (url, data, chunks))
+        if provided != 1:
+            raise ValueError("Provide exactly one of url/data/chunks")
         self._bin = ffmpeg_bin
         self._url = url
         self._data = data
+        self._chunks = chunks
 
     async def run(self, push: PushFn, is_active: ActiveFn) -> None:
         src = self._url if self._url is not None else "pipe:0"
+        use_stdin = self._data is not None or self._chunks is not None
         proc = await asyncio.create_subprocess_exec(
             self._bin,
             "-hide_banner",
@@ -309,13 +318,16 @@ class FfmpegAudioSource(_ConfiguredPcmSource):
             "-f",
             "s16le",
             "pipe:1",
-            stdin=asyncio.subprocess.PIPE if self._data is not None else None,
+            stdin=asyncio.subprocess.PIPE if use_stdin else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
         assert proc.stdout is not None
+        feeder: asyncio.Task | None = None
         try:
-            if self._data is not None and proc.stdin is not None:
+            if self._chunks is not None and proc.stdin is not None:
+                feeder = asyncio.create_task(self._feed_stdin(proc.stdin))
+            elif self._data is not None and proc.stdin is not None:
                 proc.stdin.write(self._data)
                 proc.stdin.write_eof()
 
@@ -339,12 +351,39 @@ class FfmpegAudioSource(_ConfiguredPcmSource):
             if buf and is_active():
                 push(bytes(buf))
         finally:
+            if feeder is not None:
+                feeder.cancel()
+                try:
+                    await feeder
+                except asyncio.CancelledError:
+                    pass
             if proc.returncode is None:
                 try:
                     proc.kill()
                 except ProcessLookupError:
                     pass
             await proc.wait()
+
+    async def _feed_stdin(self, stdin: asyncio.StreamWriter) -> None:
+        """Write streaming chunks to ffmpeg; close stdin when the producer ends."""
+        chunks = self._chunks
+        assert chunks is not None
+        try:
+            async for chunk in chunks:
+                if not chunk:
+                    continue
+                stdin.write(chunk)
+                await stdin.drain()
+            stdin.write_eof()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        finally:
+            aclose = getattr(chunks, "aclose", None)
+            if callable(aclose):
+                try:
+                    await aclose()
+                except Exception:  # noqa: BLE001
+                    pass
 
 
 _TONE_PCM_CACHE: dict[tuple[int, int, int, float, int], bytes] = {}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -613,6 +613,12 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 **추가된 테스트**
 - `test_ffmpeg_source_streaming_emits_pcm_before_producer_finishes`
 - `test_assist_tts_starts_before_stream_completes`
+- `test_pacer_throttles_after_a_producer_stall_burst`
+
+스트리밍 공급이 멈췄다 몰아서 오면 `_RealtimePacer`가 한 번에 TX 버퍼(1초)를
+넘기는 PCM을 밀어 앞부분을 잘라냈다. `ahead`가 `−_PCM_MAX_BEHIND_SEC` 아래로
+떨어지면 `_start`를 재동기화해 catch-up을 버퍼 크기 이내로 제한한다. 문장 중간
+무음 구간은 남을 수 있고, 그 원인은 P3-4(#45)에서 재확인한다.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -596,19 +596,23 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 ## P3 — Assist 체감 품질 (차별화 영역)
 
-### [ ] P3-1. TTS 스트리밍 재생
+### [x] P3-1. TTS 스트리밍 재생
 
-**근거** §1.3-7. `_play_tts_stream`(`assist.py:592`)이 청크를 전부 모은 뒤 ffmpeg에 넘겨
+**근거** §1.3-7. `_play_tts_stream`이 청크를 전부 모은 뒤 ffmpeg에 넘겨
 첫 음성까지 지연이 TTS 합성 전체 시간이 된다. 전화는 지연 체감이 가장 큰 매체다.
 
-**작업** `FfmpegAudioSource`에 "스트리밍 stdin" 모드를 추가하고, TTS 청크가 도착하는
-대로 ffmpeg stdin에 쓴다. `_tts_epoch` 무효화 로직은 유지해야 한다(중간에 barge-in이
-들어오면 프로세스를 죽여야 함).
+**작업** `FfmpegAudioSource`에 `chunks` 스트리밍 stdin 모드를 추가하고, TTS 첫 청크가
+도착하면 바로 재생을 시작한다. `_tts_epoch` 무효화로 barge-in 시 잔여 청크를 버린다.
+`stop_audio(flush=True)`가 ffmpeg 프로세스와 RTP 잔여 PCM을 정리한다.
 
 **수용 기준**
 - 첫 PCM이 RTP TX에 들어가는 시점이 TTS 스트림 완료를 기다리지 않는다(테스트로 검증).
 - barge-in 시 ffmpeg 프로세스가 정리되고 잔여 PCM이 flush된다.
-- 기존 Assist 테스트 40여 개가 그대로 통과한다.
+- 기존 Assist 테스트가 그대로 통과한다.
+
+**추가된 테스트**
+- `test_ffmpeg_source_streaming_emits_pcm_before_producer_finishes`
+- `test_assist_tts_starts_before_stream_completes`
 
 ---
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -228,6 +228,36 @@ def test_pacer_catches_up_after_an_event_loop_stall():
     assert slept == [0]
 
 
+def test_pacer_throttles_after_a_producer_stall_burst():
+    """A stalled streaming producer must not dump more than the TX buffer.
+
+    Cloud TTS often emits a first chunk, then a 1.5–2 s blob. After the first
+    chunk plays out, ffmpeg stdout stalls and RTP sends comfort silence. When
+    the blob arrives, unlimited catch-up would push ~1.8 s of PCM at once;
+    RtpSession's 1 s TX buffer then drops the oldest frames (speech lost).
+    Resyncing the deadline caps the dump at 1.0 s; the rest is paced.
+    """
+    p, clock = _pacer()
+    slept = []
+
+    async def fake_sleep(delay=0, result=None):
+        slept.append(delay)
+        return result
+
+    p.account(8000)              # 0.5 s first chunk
+    clock.now = 1.8              # producer gap: ahead ≈ -1.3 s
+    with patch.object(audio.asyncio, "sleep", fake_sleep):
+        asyncio.run(p.wait())
+    assert slept == [0]
+
+    p.account(8000 * 2 * 18 // 10)  # 1.8 s blob
+    with patch.object(audio.asyncio, "sleep", fake_sleep):
+        asyncio.run(p.wait())
+    # After resync the burst may fill -0.5 → +0.5 (1.0 s). Remaining 0.8 s
+    # of the blob must be throttled, not dumped (which would sleep(0)).
+    assert abs(slept[-1] - 0.8) < 1e-6
+
+
 def test_pacer_tracks_rate_for_wideband_codecs():
     """G.722 runs at 16 kHz, so the same byte count is half the duration."""
     p, clock = _pacer(sample_rate=16000)

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -286,6 +286,80 @@ def test_ffmpeg_source_reassembles_short_reads_into_whole_frames():
     assert len(chunks[-1]) == total % 320  # the tail is emitted, not dropped
 
 
+def test_ffmpeg_source_requires_exactly_one_input():
+    async def _chunks():
+        yield b"x"
+        return
+
+    try:
+        audio.FfmpegAudioSource()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+    try:
+        audio.FfmpegAudioSource(url="a", data=b"x")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+    try:
+        audio.FfmpegAudioSource(url="a", chunks=_chunks())
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_ffmpeg_source_streaming_emits_pcm_before_producer_finishes():
+    """First stdout PCM must not wait for the stdin iterable to be exhausted."""
+    script = (
+        "#!" + sys.executable + "\n"
+        "import sys\n"
+        "inp, out = sys.stdin.buffer, sys.stdout.buffer\n"
+        "while True:\n"
+        "    b = inp.read(80)\n"
+        "    if not b:\n"
+        "        break\n"
+        "    out.write(b)\n"
+        "    out.flush()\n"
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write(script)
+        path = fh.name
+    os.chmod(path, 0o755)
+
+    try:
+        pushed: list[bytes] = []
+        more = asyncio.Event()
+        producer_finished = []
+
+        async def chunks():
+            yield b"\x11" * 320
+            await more.wait()
+            producer_finished.append(True)
+            yield b"\x22" * 320
+
+        def push(data):
+            pushed.append(data)
+            if len(pushed) == 1:
+                more.set()
+
+        async def main():
+            source = audio.FfmpegAudioSource(ffmpeg_bin=path, chunks=chunks())
+            source.configure(8000, 320)
+            await asyncio.wait_for(source.run(push, lambda: True), timeout=2)
+
+        asyncio.run(main())
+    finally:
+        os.unlink(path)
+
+    assert producer_finished == [True]
+    assert pushed
+    assert pushed[0].startswith(b"\x11")
+    assert sum(len(c) for c in pushed) == 640
+
+
 # ------------------------------------------------------------ sip_message
 def test_parse_response():
     raw = (
@@ -3673,6 +3747,41 @@ def test_assist_playback_timeout_stale_tts_does_not_play():
 
     asyncio.run(run())
     assert not play_calls
+
+
+def test_assist_tts_starts_before_stream_completes():
+    """First TTS chunk must start RTP; remaining chunks must not gate play_source."""
+    assist_mod, _, _, _ = _assist_ctx()
+    play_calls: list[str] = []
+    rest = asyncio.Event()
+
+    async def gated_stream():
+        yield b"RIFF...."
+        await rest.wait()
+        yield b"more-wav"
+
+    stream = MagicMock()
+    stream.async_stream_result = gated_stream
+
+    async def run():
+        bridge = assist_mod.AssistBridge(
+            MagicMock(),
+            play_source_fn=lambda src: play_calls.append(type(src).__name__),
+            on_done_fn=MagicMock(),
+            stop_audio_fn=MagicMock(),
+        )
+        task = asyncio.create_task(bridge._play_tts_stream(stream, epoch=0))
+        for _ in range(50):
+            if play_calls:
+                break
+            await asyncio.sleep(0.01)
+        played_before_rest = list(play_calls)
+        rest.set()
+        await asyncio.wait_for(task, timeout=1)
+        return played_before_rest
+
+    played = asyncio.run(run())
+    assert played == ["FfmpegAudioSource"]
 
 
 def test_assist_playback_timeout_does_not_stop_long_playback():


### PR DESCRIPTION
## Summary
- Add `FfmpegAudioSource(chunks=...)` streaming stdin mode: ffmpeg is fed as TTS bytes arrive, concurrently with PCM readout.
- `_play_tts_stream` starts playback after the first chunk instead of `b"".join` of the whole stream, so time-to-first-audio is no longer the full synthesis time.
- `_tts_epoch` still drops stale chunks; barge-in keeps using `stop_audio(flush=True)` to kill ffmpeg and discard queued RTP.

## Test plan
- [ ] Assist TTS on a live call: speech should start before the pipeline has finished emitting the whole reply.
- [ ] Barge-in during TTS: playback stops immediately and the next STT turn starts (no leftover ffmpeg).
- [ ] `ruff check custom_components/ tests/` and `pytest tests/` (228 passed locally).


Made with [Cursor](https://cursor.com)