### PR TITLE
feat: anti-alias G.711 audio before Assist STT (P3-2)

### DIFF
--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -1,7 +1,9 @@
 """Home Assistant Assist Pipeline integration for SIP Client."""
 from __future__ import annotations
 
+import array
 import asyncio
+import math
 from collections.abc import AsyncIterable, Callable
 from typing import Literal
 
@@ -56,16 +58,85 @@ _TTS_WAIT_TIMEOUT_SECONDS = 300
 _TxWaitKind = Literal["tts", "tone"]
 
 
-def _upsample_pcm(pcm_le: bytes, sample_rate: int) -> bytes:
-    """Return 16 kHz s16le mono PCM for Assist STT / VAD."""
+def _halfband_odd_taps(half: int = 15) -> tuple[float, ...]:
+    """Odd-phase taps of a 2× Hamming half-band interpolator.
+
+    ``half=15`` is a 31-tap filter (n = −15..15). Even taps are 0 except the
+    centre tap of 1; these values are h[1], h[3], … h[15], scaled so DC gain
+    is exactly 2 (the factor that restores amplitude after zero-insertion).
+    """
+    raw: list[float] = []
+    for n in range(1, half + 1, 2):
+        sign = 1.0 if ((n - 1) // 2) % 2 == 0 else -1.0
+        ideal = sign * 2.0 / (math.pi * n)
+        window = 0.54 + 0.46 * math.cos(math.pi * n / half)
+        raw.append(ideal * window)
+    scale = 0.5 / sum(raw)
+    return tuple(c * scale for c in raw)
+
+
+# 8 input-sample (1 ms @ 8 kHz) group delay; 16-deep delay line.
+_UPSAMPLE_ODD_TAPS = _halfband_odd_taps()
+_UPSAMPLE_HIST = len(_UPSAMPLE_ODD_TAPS) * 2
+
+
+class _Upsampler2x:
+    """Causal 8 kHz → 16 kHz polyphase interpolator with anti-imaging LPF.
+
+    Even output samples are delayed originals; odd samples are the
+    interpolating phase. History is kept across ``process()`` calls so
+    20 ms RTP frames do not click at the boundaries.
+    """
+
+    __slots__ = ("_hist",)
+
+    def __init__(self) -> None:
+        self._hist = array.array("h", [0] * _UPSAMPLE_HIST)
+
+    def process(self, pcm_le: bytes) -> bytes:
+        n_in = len(pcm_le) // 2
+        if n_in == 0:
+            return b""
+        src = array.array("h")
+        src.frombytes(pcm_le[: n_in * 2])
+        hist = self._hist
+        taps = _UPSAMPLE_ODD_TAPS
+        center = len(taps) - 1
+        out = array.array("h", [0] * (n_in * 2))
+        oi = 0
+        for sample in src:
+            hist[:-1] = hist[1:]
+            hist[-1] = sample
+            even = hist[center]
+            acc = 0.0
+            for j, coeff in enumerate(taps):
+                acc += coeff * (hist[center - j] + hist[center + 1 + j])
+            odd = int(acc)
+            if odd > 32767:
+                odd = 32767
+            elif odd < -32768:
+                odd = -32768
+            out[oi] = even
+            out[oi + 1] = odd
+            oi += 2
+        return out.tobytes()
+
+
+def _upsample_pcm(
+    pcm_le: bytes,
+    sample_rate: int,
+    upsampler: _Upsampler2x | None = None,
+) -> bytes:
+    """Return 16 kHz s16le mono PCM for Assist STT / VAD.
+
+    G.722 (16 kHz) is a no-op. 8 kHz G.711 is interpolated by 2 with a
+    half-band FIR so the 4–8 kHz images of sample-and-hold do not reach STT.
+    """
     if sample_rate == 16000:
         return pcm_le
-    resampled = bytearray(len(pcm_le) * 2)
-    for i in range(0, len(pcm_le), 2):
-        sample = pcm_le[i : i + 2]
-        resampled[i * 2 : i * 2 + 2] = sample
-        resampled[i * 2 + 2 : i * 2 + 4] = sample
-    return bytes(resampled)
+    if upsampler is None:
+        upsampler = _Upsampler2x()
+    return upsampler.process(pcm_le)
 
 
 def _stt_text(data: dict | None) -> str:
@@ -184,22 +255,30 @@ class AssistBridge(AudioSink):
         self._post_barge_in_capture = False
         self._tts_epoch = 0
         self._tone_capture = bytearray()
+        self._upsampler = _Upsampler2x()
         self._micro_vad = MicroVad() if self.barge_in else None
 
     def start(self) -> None:
         """Start the Assist session loop in the background."""
         self.session_task = asyncio.create_task(self._run_session())
 
+    def _to_16k(self, pcm_le: bytes) -> bytes:
+        """Upsample G.711 RX to 16 kHz, keeping FIR history across frames."""
+        if self.sample_rate == 16000:
+            return pcm_le
+        return self._upsampler.process(pcm_le)
+
     def write(self, pcm_le: bytes) -> None:
         """Receive incoming PCM from SIP client and feed it to Assist."""
+        pcm_16k = self._to_16k(pcm_le)
         if self._listening:
-            self.audio_stream.feed_audio(pcm_le, self.sample_rate)
+            self.audio_stream.feed_audio(pcm_16k, 16000)
         elif self._tx_wait == "tone":
-            self._append_tone_capture(_upsample_pcm(pcm_le, self.sample_rate))
+            self._append_tone_capture(pcm_16k)
         elif self._post_barge_in_capture:
-            self._append_rx_to_ring(_upsample_pcm(pcm_le, self.sample_rate))
+            self._append_rx_to_ring(pcm_16k)
         elif self.barge_in and self._speaking:
-            self._monitor_barge_in(pcm_le)
+            self._monitor_barge_in(pcm_16k)
 
     def on_playback_done(self) -> None:
         """Signal that TX playback has finished (see IvrSession for the same pattern).
@@ -264,9 +343,8 @@ class AssistBridge(AudioSink):
                 _TX_IDLE_TIMEOUT_SECONDS,
             )
 
-    def _monitor_barge_in(self, pcm_le: bytes) -> None:
+    def _monitor_barge_in(self, pcm_16k: bytes) -> None:
         """Detect caller speech during TTS playback and trigger barge-in."""
-        pcm_16k = _upsample_pcm(pcm_le, self.sample_rate)
         self._append_rx_to_ring(pcm_16k)
 
         self._vad_pending.extend(pcm_16k)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -622,20 +622,27 @@ media_player 속성: `call_duration`, `audio_path`, `bytes_received`, `bytes_sen
 
 ---
 
-### [ ] P3-2. 리샘플러 품질 개선
+### [x] P3-2. 리샘플러 품질 개선
 
-**근거** §1.3-7. `_upsample_pcm`(`assist.py:59`)이 샘플 복제라 4~8 kHz 이미지 성분이
-생겨 STT 인식률을 깎고, 순수 파이썬 루프가 이벤트 루프에서 20 ms마다 돈다.
+**근거** §1.3-7. `_upsample_pcm`이 샘플 복제라 4~8 kHz 이미지 성분이 생겨 STT
+인식률을 깎고, 순수 파이썬 루프가 이벤트 루프에서 20 ms마다 돈다.
 
-**작업** 8k→16k 업샘플에 anti-imaging 필터를 적용한다. 선택지:
-- 짧은 FIR 저역통과 + `array`/`memoryview` 기반 구현 (의존성 없음)
-- HA에 이미 있는 의존성 활용 가능 여부 확인 (`audioop`은 Python 3.13에서 제거됨 — 사용 불가)
-- 최후 수단: ffmpeg 경유 (프로세스 비용 때문에 비권장)
+**작업** 8k→16k를 31-tap Hamming half-band FIR로 2× 보간한다. 의존성 없음
+(`array` + 짧은 파이썬 루프). `audioop`은 3.13에서 제거됐고 ffmpeg 경유는
+프레임마다 프로세스 비용이 커서 쓰지 않는다. G.722(16 kHz)는 no-op.
+FIR 히스토리는 `AssistBridge`가 프레임 사이에 유지한다.
 
 **수용 기준**
 - 1 kHz / 3 kHz 사인파 업샘플 결과에서 이미지 성분이 기존 구현보다 측정 가능하게 감소한다.
 - 20 ms 프레임 처리 시간이 예산 내다(`test_g722_perf_under_budget` 패턴 참고).
 - G.722(16 kHz) 경로는 여전히 no-op으로 우회된다.
+
+**추가된 테스트**
+- `test_upsample_pcm_is_noop_at_16khz`
+- `test_upsample_pcm_doubles_8khz_length`
+- `test_upsample_pcm_reduces_imaging_vs_zoh`
+- `test_upsample_pcm_frame_budget`
+- `test_upsample_pcm_is_stable_across_frames`
 
 ---
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -3151,6 +3151,102 @@ def _initial_prompt_doubles(PET, PE, *events):
     )
 
 
+def _zoh_upsample(pcm_le: bytes) -> bytes:
+    """Sample-and-hold 8 kHz → 16 kHz (the pre-P3-2 implementation)."""
+    out = bytearray(len(pcm_le) * 2)
+    for i in range(0, len(pcm_le), 2):
+        sample = pcm_le[i : i + 2]
+        out[i * 2 : i * 2 + 4] = sample + sample
+    return bytes(out)
+
+
+def _sine_pcm(freq_hz: float, sample_rate: int, n_samples: int, amplitude: int = 8000) -> bytes:
+    import math
+
+    return struct.pack(
+        f"<{n_samples}h",
+        *[
+            int(amplitude * math.sin(2 * math.pi * freq_hz * i / sample_rate))
+            for i in range(n_samples)
+        ],
+    )
+
+
+def _goertzel_power(samples, sample_rate: int, freq_hz: float) -> float:
+    import math
+
+    n = len(samples)
+    k = int(0.5 + n * freq_hz / sample_rate)
+    coeff = 2 * math.cos(2 * math.pi * k / n)
+    s0 = s1 = s2 = 0.0
+    for value in samples:
+        s0 = value + coeff * s1 - s2
+        s2, s1 = s1, s0
+    return (s1 * s1 + s2 * s2 - coeff * s1 * s2) / (n * n)
+
+
+def _image_ratio_db(pcm_16k: bytes, tone_hz: float) -> float:
+    import math
+
+    samples = list(struct.unpack(f"<{len(pcm_16k) // 2}h", pcm_16k))[32:]
+    pass_p = _goertzel_power(samples, 16000, tone_hz)
+    img_p = _goertzel_power(samples, 16000, 8000 - tone_hz)
+    return 10 * math.log10((img_p + 1e-18) / (pass_p + 1e-18))
+
+
+def test_upsample_pcm_is_noop_at_16khz():
+    assist_mod, _, _, _ = _assist_ctx()
+    pcm = b"\x01\x02\x03\x04"
+    assert assist_mod._upsample_pcm(pcm, 16000) is pcm
+
+
+def test_upsample_pcm_doubles_8khz_length():
+    assist_mod, _, _, _ = _assist_ctx()
+    pcm = _sine_pcm(1000, 8000, 160)
+    out = assist_mod._upsample_pcm(pcm, 8000)
+    assert len(out) == len(pcm) * 2
+
+
+def test_upsample_pcm_reduces_imaging_vs_zoh():
+    """1 kHz / 3 kHz tones must not leak a 7 / 5 kHz image into STT."""
+    assist_mod, _, _, _ = _assist_ctx()
+    for tone_hz in (1000, 3000):
+        src = _sine_pcm(tone_hz, 8000, 4096)
+        zoh_db = _image_ratio_db(_zoh_upsample(src), tone_hz)
+        fir_db = _image_ratio_db(assist_mod._upsample_pcm(src, 8000), tone_hz)
+        assert fir_db < zoh_db - 20, (tone_hz, zoh_db, fir_db)
+
+
+def test_upsample_pcm_frame_budget():
+    """A 20 ms G.711 frame must stay well inside the RTP period (Pi headroom)."""
+    import time
+
+    assist_mod, _, _, _ = _assist_ctx()
+    pcm = _sine_pcm(440, 8000, 160)
+    upsampler = assist_mod._Upsampler2x()
+    for _ in range(5):
+        upsampler.process(pcm)
+    t0 = time.perf_counter()
+    n = 50
+    for _ in range(n):
+        upsampler.process(pcm)
+    us = (time.perf_counter() - t0) / n * 1e6
+    assert us < 15000, f"upsample took {us:.0f} µs/frame"
+
+
+def test_upsample_pcm_is_stable_across_frames():
+    """Per-frame process() must match a one-shot run (FIR history is kept)."""
+    assist_mod, _, _, _ = _assist_ctx()
+    src = _sine_pcm(1000, 8000, 480)
+    oneshot = assist_mod._upsample_pcm(src, 8000)
+    upsampler = assist_mod._Upsampler2x()
+    frame = 160 * 2
+    parts = b"".join(
+        upsampler.process(src[off : off + frame]) for off in range(0, len(src), frame)
+    )
+    assert parts == oneshot
+
+
 def test_assist_listening_gate():
     assist_mod, _, _, _ = _assist_ctx()
     bridge = assist_mod.AssistBridge(


### PR DESCRIPTION
## Summary
- Replace 8 kHz sample-and-hold (`_upsample_pcm`) with a 31-tap Hamming half-band FIR (2× polyphase interpolator, no extra dependencies). The 5 kHz / 7 kHz images of 3 kHz / 1 kHz tones drop by more than 20 dB versus ZOH.
- `AssistBridge` keeps FIR history across 20 ms RTP frames so the filter does not click at boundaries. G.722 (16 kHz) remains a no-op.
- A 20 ms G.711 frame stays well inside the existing 15 ms budget (`test_g722_perf_under_budget` pattern).

## Test plan
- [x] `python -m pytest tests/` (234 passed on Python 3.12)
- [x] `ruff check custom_components/ tests/`
- [ ] G.711 Assist call: STT should not be worse than before (images at 5–7 kHz are gone)
- [ ] G.722 Assist call: PCM still reaches STT at native 16 kHz with no resampling


Made with [Cursor](https://cursor.com)