### PR TITLE
feat: gate Assist with caller allow-list and optional DTMF PIN (P4-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ The session ends when:
 - `noise_suppression` *(Optional)*: Noise suppression level applied to caller audio, `0` (off) to `4` (max). Helps on noisy narrowband G.711 lines where line noise is otherwise mistaken for speech.
 - `turn_tone` *(Optional)*: Play a short beep when the microphone opens for the next turn (default: `false`). After TTS there is a brief guard before the next pipeline starts; speech in that window is prerolled when voice activity is detected. A completed beep drops the guard/tone capture so speakerphone echo of the beep does not reach STT — speak after the beep. Skipped on barge-in turns that already have preroll, and left off by default so existing calls and IVR `assist: true` prompts are unchanged.
 - `hangup_on_end` *(Optional)*: Hang up the call when the Assist session ends (default: `false`).
+- `allowed_callers` *(Optional)*: Caller IDs that may start Assist. Omitted means no restriction, so existing automations keep working. Matching uses the SIP user-part (`100`, `sip:100@pbx`, and `<sip:100@host>` all compare as `100`). An empty list allows nobody.
+- `contacts_only` *(Optional)*: Only callers listed in `sip_contacts.json` may start Assist (default: `false`). Combined with `allowed_callers`, the caller must match **both**.
+- `pin` *(Optional)*: DTMF PIN collected before Assist starts. The caller enters the digits and either presses `#` or matches the PIN length (15 s timeout). Failed, hung-up, or timed-out attempts fire `sip_assist_rejected` and do **not** run intents. The PIN is never logged or included in events.
+
+> **Caller ID can be spoofed.** An allow-list alone is not a security boundary. For door-lock or other security intents, use **allow-list + PIN + a dedicated Assist pipeline** that only exposes those intents. IVR `assist: true` does not use this gate — give that menu its own PIN if needed.
+
+```yaml
+  - service: sip.start_assist
+    target:
+      entity_id: media_player.phone_line
+    data:
+      allowed_callers:
+        - "100"
+        - "101"
+      contacts_only: true
+      pin: "1234"
+      pipeline_id: "door-lock-pipeline"
+```
 
 > **Tuning for phone calls**: the Assist defaults assume a smart speaker's microphone. On a telephone line, line noise and codec artefacts can trip the voice detector before the caller speaks — the symptom is a reply to a cough or a breath, followed by the real question being split across two turns. Raising `silence_seconds` and enabling `noise_suppression` addresses the first part. Enabling `turn_tone` adds an audible cue when it is the caller's turn to speak. Speech that starts right after TTS is forwarded into the next turn as preroll when it looks like voice (not echo of the reply or the beep). Enabling `barge_in` (handsets only) additionally lets a caller talk over a response instead of waiting for it to finish.
 
@@ -182,6 +200,7 @@ Supported event types (`event_type` attribute):
 - `dtmf`: Fired when a DTMF key is pressed. Attributes: `digit`.
 - `recording_started` / `recording_stopped`: Fired when call recording starts or stops.
 - `registered`: Fired when the SIP client registers successfully.
+- `assist_rejected`: Fired when `sip.start_assist` refuses the caller. Attributes: `caller`, `reason` (`not_allowed`, `pin_mismatch`, `pin_timeout`).
 
 #### Example Event Trigger:
 ```yaml
@@ -206,6 +225,7 @@ If you prefer triggering directly from the Event Bus, the integration fires the 
 | `sip_dtmf_digit` | `digit` | A DTMF digit was received from the remote party |
 | `sip_recording_started` | `recording_file` | Call recording started |
 | `sip_recording_stopped` | – | Call recording stopped |
+| `sip_assist_rejected` | `caller`, `reason` | Assist was refused (`not_allowed`, `pin_mismatch`, or `pin_timeout`) |
 
 > `sip_call_connected` and `sip_playback_done` are the two events/states you want for "answer → speak → hang up" flows: wait for the call to connect before playing media, and wait for playback to finish before hanging up so the message is never cut off.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The session ends when:
 - `contacts_only` *(Optional)*: Only callers listed in `sip_contacts.json` may start Assist (default: `false`). Combined with `allowed_callers`, the caller must match **both**.
 - `pin` *(Optional)*: DTMF PIN collected before Assist starts. The caller enters the digits and either presses `#` or matches the PIN length (15 s timeout). Failed, hung-up, or timed-out attempts fire `sip_assist_rejected` and do **not** run intents. While the PIN is collected, digits are not logged and `sip_dtmf_digit` is not fired, so the PIN cannot be reconstructed from Logbook or automations.
 
-> **Caller ID can be spoofed.** An allow-list alone is not a security boundary. For door-lock or other security intents, use **allow-list + PIN + a dedicated Assist pipeline** that only exposes those intents. IVR `assist: true` does not use this gate — give that menu its own PIN if needed.
+> **Caller ID can be spoofed.** An allow-list alone is not a security boundary. For door-lock or other security intents, use **allow-list + PIN + a dedicated Assist pipeline** that only exposes those intents. IVR `assist: true` does not use this gate — give that menu its own PIN if needed. SIP INFO DTMF digits can still appear in DEBUG logs and opt-in SIP traces (`Signal=` in INFO bodies); do not attach those logs to an issue if a PIN was entered.
 
 ```yaml
   - service: sip.start_assist
@@ -708,4 +708,4 @@ action:
       custom_components.sip.sip_client.trace: debug
   ```
 
-  `Authorization` / `Proxy-Authorization` values (`response`, `nonce`, `cnonce`) are masked as `****`. RTP is summarised (packet counts, payload type, estimated loss, latched address), not logged packet-by-packet. That YAML logger is the narrow switch; the integration's **Enable debug logging** button also turns this on, because it sets `custom_components.sip` (and therefore this child logger) to DEBUG — credentials stay masked, but phone numbers and SDP will be in the log you download for an issue. Turn the logger back to `info` when you are done.
+  `Authorization` / `Proxy-Authorization` values (`response`, `nonce`, `cnonce`) are masked as `****`. RTP is summarised (packet counts, payload type, estimated loss, latched address), not logged packet-by-packet. That YAML logger is the narrow switch; the integration's **Enable debug logging** button also turns this on, because it sets `custom_components.sip` (and therefore this child logger) to DEBUG — credentials stay masked, but phone numbers, SDP, and SIP INFO DTMF digits (including an Assist PIN) will be in the log you download for an issue. Turn the logger back to `info` when you are done.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The session ends when:
 - `hangup_on_end` *(Optional)*: Hang up the call when the Assist session ends (default: `false`).
 - `allowed_callers` *(Optional)*: Caller IDs that may start Assist. Omitted means no restriction, so existing automations keep working. Matching uses the SIP user-part (`100`, `sip:100@pbx`, and `<sip:100@host>` all compare as `100`). An empty list allows nobody.
 - `contacts_only` *(Optional)*: Only callers listed in `sip_contacts.json` may start Assist (default: `false`). Combined with `allowed_callers`, the caller must match **both**.
-- `pin` *(Optional)*: DTMF PIN collected before Assist starts. The caller enters the digits and either presses `#` or matches the PIN length (15 s timeout). Failed, hung-up, or timed-out attempts fire `sip_assist_rejected` and do **not** run intents. The PIN is never logged or included in events.
+- `pin` *(Optional)*: DTMF PIN collected before Assist starts. The caller enters the digits and either presses `#` or matches the PIN length (15 s timeout). Failed, hung-up, or timed-out attempts fire `sip_assist_rejected` and do **not** run intents. While the PIN is collected, digits are not logged and `sip_dtmf_digit` is not fired, so the PIN cannot be reconstructed from Logbook or automations.
 
 > **Caller ID can be spoofed.** An allow-list alone is not a security boundary. For door-lock or other security intents, use **allow-list + PIN + a dedicated Assist pipeline** that only exposes those intents. IVR `assist: true` does not use this gate — give that menu its own PIN if needed.
 

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -19,6 +19,11 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import async_extract_config_entry_ids
 
 from .assist import AssistBridge
+from .assist_gate import (
+    REASON_NOT_ALLOWED,
+    PinCollector,
+    caller_is_allowed,
+)
 from .const import (
     CONF_CALLER_ID,
     CONF_DOMAIN,
@@ -35,6 +40,7 @@ from .const import (
     DEFAULT_MEDIA_TIMEOUT,
     DEFAULT_MAX_CALL_DURATION,
     DOMAIN,
+    EVENT_SIP_ASSIST_REJECTED,
     EVENT_SIP_CALL_CONNECTED,
     EVENT_SIP_CALL_ENDED,
     EVENT_SIP_DTMF_DIGIT,
@@ -80,6 +86,20 @@ def _fire_recording_stopped(hass: HomeAssistant, entry_id: str, data: dict) -> N
         f"{DOMAIN}_event_{entry_id}",
         EVENT_SIP_RECORDING_STOPPED,
         None,
+    )
+
+
+def _fire_assist_rejected(
+    hass: HomeAssistant, entry_id: str, data: dict, caller: str, reason: str
+) -> None:
+    extra = {"caller": caller, "reason": reason}
+    payload = {"sip_account": data["config"].username, **extra}
+    device_id = _sip_device_id(hass, entry_id)
+    if device_id:
+        payload["device_id"] = device_id
+    hass.bus.async_fire(EVENT_SIP_ASSIST_REJECTED, payload)
+    async_dispatcher_send(
+        hass, f"{DOMAIN}_event_{entry_id}", EVENT_SIP_ASSIST_REJECTED, extra
     )
 
 
@@ -189,6 +209,9 @@ SERVICE_ASSIST_SCHEMA = cv.make_entity_service_schema(
         ),
         vol.Optional("turn_tone"): cv.boolean,
         vol.Optional("hangup_on_end"): cv.boolean,
+        vol.Optional("allowed_callers"): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional("contacts_only"): cv.boolean,
+        vol.Optional("pin"): cv.string,
     }
 )
 
@@ -229,6 +252,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "last_registered_at": None,
         "contacts": contacts,
         "call_number": "",
+        "pin_collector": None,
     }
 
     # Active session state helpers
@@ -345,6 +369,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     @callback
     def on_call_ended(reason: str = "local") -> None:
         LOGGER.info("[%s] Call ended (%s)", sip_config.username, reason)
+        collector = entry.runtime_data.get("pin_collector")
+        if collector is not None:
+            collector.fail()
+            entry.runtime_data["pin_collector"] = None
 
         # Save to call history log
         start_time = entry.runtime_data.get("call_start_time")
@@ -409,6 +437,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def on_dtmf(digit: str) -> None:
         LOGGER.debug("[%s] DTMF digit received: %s", sip_config.username, digit)
         fire_sip_event(EVENT_SIP_DTMF_DIGIT, {"digit": digit})
+        collector = entry.runtime_data.get("pin_collector")
+        if collector is not None:
+            collector.handle_digit(digit)
         nonlocal ivr_session
         if ivr_session is not None:
             hass.async_create_task(ivr_session.handle_dtmf(digit))
@@ -927,7 +958,33 @@ async def async_register_services(hass: HomeAssistant) -> None:
             )
             if k in call.data
         }
+        allowed_callers = call.data.get("allowed_callers")
+        contacts_only = bool(call.data.get("contacts_only"))
+        pin = call.data.get("pin") or ""
         for entry_id, data in targets:
+            caller = str(data.get("call_number") or "")
+            if not caller_is_allowed(
+                caller,
+                allowed_callers=allowed_callers,
+                contacts=data.get("contacts"),
+                contacts_only=contacts_only,
+            ):
+                LOGGER.info("Assist rejected for caller %s (not allowed)", caller)
+                _fire_assist_rejected(
+                    hass, entry_id, data, caller, REASON_NOT_ALLOWED
+                )
+                continue
+            if pin:
+                collector = PinCollector(pin)
+                data["pin_collector"] = collector
+                try:
+                    pin_result = await collector.wait()
+                finally:
+                    data["pin_collector"] = None
+                if pin_result != "ok":
+                    LOGGER.info("Assist rejected for caller %s (%s)", caller, pin_result)
+                    _fire_assist_rejected(hass, entry_id, data, caller, pin_result)
+                    continue
             await data["trigger_assist_fn"](**opts)
 
     # Register all services

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -23,6 +23,7 @@ from .assist_gate import (
     REASON_NOT_ALLOWED,
     PinCollector,
     caller_is_allowed,
+    take_pin_digit,
 )
 from .const import (
     CONF_CALLER_ID,
@@ -435,11 +436,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     @callback
     def on_dtmf(digit: str) -> None:
+        collector = entry.runtime_data.get("pin_collector")
+        if take_pin_digit(collector, digit):
+            return
         LOGGER.debug("[%s] DTMF digit received: %s", sip_config.username, digit)
         fire_sip_event(EVENT_SIP_DTMF_DIGIT, {"digit": digit})
-        collector = entry.runtime_data.get("pin_collector")
-        if collector is not None:
-            collector.handle_digit(digit)
         nonlocal ivr_session
         if ivr_session is not None:
             hass.async_create_task(ivr_session.handle_dtmf(digit))

--- a/custom_components/sip/assist_gate.py
+++ b/custom_components/sip/assist_gate.py
@@ -9,11 +9,18 @@ REASON_PIN_MISMATCH = "pin_mismatch"
 REASON_PIN_TIMEOUT = "pin_timeout"
 
 _PIN_WAIT_SECONDS = 15.0
-_USER_PART = re.compile(r"[+\d*]+")
+_PHONE_USER = re.compile(r"^\+?[\d*#]+$")
 
 
 def normalize_caller(value: str) -> str:
-    """Return a comparable caller identity (SIP URI user-part or extension)."""
+    """Return a comparable caller identity (SIP URI user-part or extension).
+
+    Phone-like user parts (optional ``+``, then digits / ``*`` / ``#``) are
+    compared after stripping spaces and dashes. Alphanumeric extensions
+    (``doorbird1``, ``kitchen1``, ``cam2``) keep the full lowercased user-part
+    so a shared trailing digit cannot collapse distinct names onto one allow
+    list entry.
+    """
     raw = (value or "").strip()
     if raw.startswith("<") and raw.endswith(">"):
         raw = raw[1:-1].strip()
@@ -24,9 +31,10 @@ def normalize_caller(value: str) -> str:
         raw = raw[5:]
     if "@" in raw:
         raw = raw.split("@", 1)[0]
-    raw = raw.replace(" ", "").replace("-", "")
-    match = _USER_PART.search(raw)
-    return match.group(0) if match else raw
+    ident = raw.replace(" ", "").replace("-", "").lower()
+    if _PHONE_USER.fullmatch(ident):
+        return ident
+    return ident
 
 
 def caller_is_allowed(
@@ -96,3 +104,15 @@ class PinCollector:
         except TimeoutError:
             self.fail()
             return REASON_PIN_TIMEOUT
+
+
+def take_pin_digit(collector: PinCollector | None, digit: str) -> bool:
+    """Consume ``digit`` for an active PIN wait.
+
+    Returns True when the digit was handled privately. The caller must not
+    log it or fire ``sip_dtmf_digit``.
+    """
+    if collector is None:
+        return False
+    collector.handle_digit(digit)
+    return True

--- a/custom_components/sip/assist_gate.py
+++ b/custom_components/sip/assist_gate.py
@@ -2,24 +2,21 @@
 from __future__ import annotations
 
 import asyncio
-import re
 
 REASON_NOT_ALLOWED = "not_allowed"
 REASON_PIN_MISMATCH = "pin_mismatch"
 REASON_PIN_TIMEOUT = "pin_timeout"
 
 _PIN_WAIT_SECONDS = 15.0
-_PHONE_USER = re.compile(r"^\+?[\d*#]+$")
 
 
 def normalize_caller(value: str) -> str:
     """Return a comparable caller identity (SIP URI user-part or extension).
 
-    Phone-like user parts (optional ``+``, then digits / ``*`` / ``#``) are
-    compared after stripping spaces and dashes. Alphanumeric extensions
-    (``doorbird1``, ``kitchen1``, ``cam2``) keep the full lowercased user-part
-    so a shared trailing digit cannot collapse distinct names onto one allow
-    list entry.
+    Strips SIP wrapping, spaces, and dashes, then lowercases the user-part.
+    Phone numbers stay numbers (``100``, ``+821012345678``). Alphanumeric
+    extensions (``doorbird1``, ``kitchen1``, ``cam2``) keep the full name so a
+    shared trailing digit cannot collapse distinct identities.
     """
     raw = (value or "").strip()
     if raw.startswith("<") and raw.endswith(">"):
@@ -31,10 +28,7 @@ def normalize_caller(value: str) -> str:
         raw = raw[5:]
     if "@" in raw:
         raw = raw.split("@", 1)[0]
-    ident = raw.replace(" ", "").replace("-", "").lower()
-    if _PHONE_USER.fullmatch(ident):
-        return ident
-    return ident
+    return raw.replace(" ", "").replace("-", "").lower()
 
 
 def caller_is_allowed(

--- a/custom_components/sip/assist_gate.py
+++ b/custom_components/sip/assist_gate.py
@@ -1,0 +1,98 @@
+"""Assist caller allow-list and PIN gate. Kept free of Home Assistant imports."""
+from __future__ import annotations
+
+import asyncio
+import re
+
+REASON_NOT_ALLOWED = "not_allowed"
+REASON_PIN_MISMATCH = "pin_mismatch"
+REASON_PIN_TIMEOUT = "pin_timeout"
+
+_PIN_WAIT_SECONDS = 15.0
+_USER_PART = re.compile(r"[+\d*]+")
+
+
+def normalize_caller(value: str) -> str:
+    """Return a comparable caller identity (SIP URI user-part or extension)."""
+    raw = (value or "").strip()
+    if raw.startswith("<") and raw.endswith(">"):
+        raw = raw[1:-1].strip()
+    lower = raw.lower()
+    if lower.startswith("sip:"):
+        raw = raw[4:]
+    elif lower.startswith("sips:"):
+        raw = raw[5:]
+    if "@" in raw:
+        raw = raw.split("@", 1)[0]
+    raw = raw.replace(" ", "").replace("-", "")
+    match = _USER_PART.search(raw)
+    return match.group(0) if match else raw
+
+
+def caller_is_allowed(
+    caller: str,
+    *,
+    allowed_callers: list[str] | None = None,
+    contacts: dict | None = None,
+    contacts_only: bool = False,
+) -> bool:
+    """True when Assist may start for ``caller``.
+
+    No list and ``contacts_only`` false keeps the historical open behaviour.
+    An explicit list and ``contacts_only`` both set must all match (intersection).
+    """
+    if allowed_callers is None and not contacts_only:
+        return True
+    ident = normalize_caller(caller)
+    if not ident:
+        return False
+    if allowed_callers is not None:
+        allowed = {normalize_caller(item) for item in allowed_callers if item}
+        if ident not in allowed:
+            return False
+    if contacts_only:
+        keys = {normalize_caller(str(key)) for key in (contacts or {})}
+        if ident not in keys:
+            return False
+    return True
+
+
+class PinCollector:
+    """Collect DTMF until it matches ``expected`` or times out.
+
+    The entered digits are never exposed on the result (ok / mismatch / timeout).
+    """
+
+    def __init__(self, expected: str) -> None:
+        self._expected = expected
+        self._buf = ""
+        self._result: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+
+    def handle_digit(self, digit: str) -> None:
+        if self._result.done() or not digit:
+            return
+        if digit == "#":
+            self._finish(self._buf == self._expected)
+            return
+        self._buf += digit
+        if self._expected and len(self._buf) >= len(self._expected):
+            self._finish(self._buf == self._expected)
+
+    def fail(self) -> None:
+        """Treat hangup as a failed PIN attempt."""
+        self._finish(False)
+
+    def _finish(self, ok: bool) -> None:
+        if not self._result.done():
+            self._result.set_result(ok)
+
+    async def wait(self, timeout: float | None = None) -> str:
+        if timeout is None:
+            timeout = _PIN_WAIT_SECONDS
+        try:
+            async with asyncio.timeout(timeout):
+                ok = await self._result
+            return "ok" if ok else REASON_PIN_MISMATCH
+        except TimeoutError:
+            self.fail()
+            return REASON_PIN_TIMEOUT

--- a/custom_components/sip/const.py
+++ b/custom_components/sip/const.py
@@ -35,4 +35,5 @@ EVENT_SIP_DTMF_DIGIT = "sip_dtmf_digit"
 EVENT_SIP_PLAYBACK_DONE = "sip_playback_done"
 EVENT_SIP_RECORDING_STARTED = "sip_recording_started"
 EVENT_SIP_RECORDING_STOPPED = "sip_recording_stopped"
+EVENT_SIP_ASSIST_REJECTED = "sip_assist_rejected"
 

--- a/custom_components/sip/event.py
+++ b/custom_components/sip/event.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .helpers import build_device_info
 from .const import (
     DOMAIN,
+    EVENT_SIP_ASSIST_REJECTED,
     EVENT_SIP_CALL_CONNECTED,
     EVENT_SIP_CALL_ENDED,
     EVENT_SIP_DTMF_DIGIT,
@@ -49,6 +50,7 @@ class SipTelephonyEventEntity(EventEntity):
         "recording_started",
         "recording_stopped",
         "registered",
+        "assist_rejected",
     ]
 
     def __init__(self, config_entry: ConfigEntry, entry_data: dict[str, Any]) -> None:
@@ -92,6 +94,8 @@ class SipTelephonyEventEntity(EventEntity):
             mapped_type = "recording_stopped"
         elif event_type == EVENT_SIP_REGISTERED:
             mapped_type = "registered"
+        elif event_type == EVENT_SIP_ASSIST_REJECTED:
+            mapped_type = "assist_rejected"
 
         if mapped_type in self._attr_event_types:
             self._trigger_event(mapped_type, extra_data or {})

--- a/custom_components/sip/logbook.py
+++ b/custom_components/sip/logbook.py
@@ -16,6 +16,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 
 from .const import (
     DOMAIN,
+    EVENT_SIP_ASSIST_REJECTED,
     EVENT_SIP_CALL_CONNECTED,
     EVENT_SIP_CALL_ENDED,
     EVENT_SIP_DTMF_DIGIT,
@@ -77,6 +78,16 @@ def async_describe_events(
     def describe_registered(event: Event) -> dict[str, str]:
         return {LOGBOOK_ENTRY_NAME: _name(event.data), LOGBOOK_ENTRY_MESSAGE: "registered"}
 
+    @callback
+    def describe_assist_rejected(event: Event) -> dict[str, str]:
+        data = event.data
+        who = data.get("caller") or "unknown"
+        reason = data.get("reason") or "rejected"
+        return {
+            LOGBOOK_ENTRY_NAME: _name(data),
+            LOGBOOK_ENTRY_MESSAGE: f"Assist rejected ({reason}) for {who}",
+        }
+
     async_describe_event(DOMAIN, EVENT_SIP_INCOMING_CALL, describe_incoming)
     async_describe_event(DOMAIN, EVENT_SIP_CALL_CONNECTED, describe_connected)
     async_describe_event(DOMAIN, EVENT_SIP_CALL_ENDED, describe_ended)
@@ -85,3 +96,4 @@ def async_describe_events(
     async_describe_event(DOMAIN, EVENT_SIP_RECORDING_STARTED, describe_recording_started)
     async_describe_event(DOMAIN, EVENT_SIP_RECORDING_STOPPED, describe_recording_stopped)
     async_describe_event(DOMAIN, EVENT_SIP_REGISTERED, describe_registered)
+    async_describe_event(DOMAIN, EVENT_SIP_ASSIST_REJECTED, describe_assist_rejected)

--- a/custom_components/sip/services.yaml
+++ b/custom_components/sip/services.yaml
@@ -284,3 +284,27 @@ start_assist:
       default: false
       selector:
         boolean:
+    allowed_callers:
+      name: Allowed callers
+      description: Caller IDs that may start Assist. Omitted means no restriction. Caller ID can be spoofed; pair with PIN for door-lock intents.
+      required: false
+      example:
+        - "100"
+        - "101"
+      selector:
+        text:
+          multiple: true
+    contacts_only:
+      name: Contacts only
+      description: Only callers listed in sip_contacts.json may start Assist. Combined with Allowed callers, both must match.
+      required: false
+      default: false
+      selector:
+        boolean:
+    pin:
+      name: PIN
+      description: Optional DTMF PIN entered before Assist starts. Failed or timed-out attempts fire sip_assist_rejected and do not run intents.
+      required: false
+      selector:
+        text:
+          type: password

--- a/custom_components/sip/strings.json
+++ b/custom_components/sip/strings.json
@@ -121,7 +121,8 @@
               "ended": "Call Ended",
               "recording_started": "Recording Started",
               "recording_stopped": "Recording Stopped",
-              "registered": "Registered"
+              "registered": "Registered",
+              "assist_rejected": "Assist Rejected"
             }
           }
         }
@@ -270,6 +271,18 @@
         "hangup_on_end": {
           "name": "Hang up on end",
           "description": "Hang up the call when the Assist session ends."
+        },
+        "allowed_callers": {
+          "name": "Allowed callers",
+          "description": "Caller IDs that may start Assist. Omitted means no restriction. Caller ID can be spoofed; pair with PIN for door-lock intents."
+        },
+        "contacts_only": {
+          "name": "Contacts only",
+          "description": "Only callers listed in sip_contacts.json may start Assist. Combined with Allowed callers, both must match."
+        },
+        "pin": {
+          "name": "PIN",
+          "description": "Optional DTMF PIN. The caller must enter it (end with # or the PIN length) before Assist starts. Failed or timed-out attempts fire sip_assist_rejected and do not run intents."
         }
       }
     }

--- a/custom_components/sip/translations/de.json
+++ b/custom_components/sip/translations/de.json
@@ -121,7 +121,8 @@
               "ended": "Anruf beendet",
               "recording_started": "Aufnahme gestartet",
               "recording_stopped": "Aufnahme gestoppt",
-              "registered": "Registriert"
+              "registered": "Registriert",
+              "assist_rejected": "Assist abgelehnt"
             }
           }
         }
@@ -270,6 +271,18 @@
         "hangup_on_end": {
           "name": "Bei Ende auflegen",
           "description": "Anruf beenden, wenn die Assist-Sitzung endet."
+        },
+        "allowed_callers": {
+          "name": "Erlaubte Anrufer",
+          "description": "Anrufer-IDs, die Assist starten dürfen. Ohne Angabe keine Einschränkung. Caller-ID ist fälschbar; für Türschloss-Intents zusätzlich PIN verwenden."
+        },
+        "contacts_only": {
+          "name": "Nur Kontakte",
+          "description": "Nur in sip_contacts.json eingetragene Anrufer dürfen Assist starten. Zusammen mit Erlaubte Anrufer müssen beide zutreffen."
+        },
+        "pin": {
+          "name": "PIN",
+          "description": "Optionale DTMF-PIN. Muss vor Assist eingegeben werden (# oder PIN-Länge). Fehlversuch oder Timeout löst sip_assist_rejected aus und führt keine Intents aus."
         }
       }
     }

--- a/custom_components/sip/translations/en.json
+++ b/custom_components/sip/translations/en.json
@@ -121,7 +121,8 @@
               "ended": "Call Ended",
               "recording_started": "Recording Started",
               "recording_stopped": "Recording Stopped",
-              "registered": "Registered"
+              "registered": "Registered",
+              "assist_rejected": "Assist Rejected"
             }
           }
         }
@@ -270,6 +271,18 @@
         "hangup_on_end": {
           "name": "Hang up on end",
           "description": "Hang up the call when the Assist session ends."
+        },
+        "allowed_callers": {
+          "name": "Allowed callers",
+          "description": "Caller IDs that may start Assist. Omitted means no restriction. Caller ID can be spoofed; pair with PIN for door-lock intents."
+        },
+        "contacts_only": {
+          "name": "Contacts only",
+          "description": "Only callers listed in sip_contacts.json may start Assist. Combined with Allowed callers, both must match."
+        },
+        "pin": {
+          "name": "PIN",
+          "description": "Optional DTMF PIN. The caller must enter it (end with # or the PIN length) before Assist starts. Failed or timed-out attempts fire sip_assist_rejected and do not run intents."
         }
       }
     }

--- a/custom_components/sip/translations/ko.json
+++ b/custom_components/sip/translations/ko.json
@@ -121,7 +121,8 @@
               "ended": "통화 종료됨",
               "recording_started": "녹음 시작됨",
               "recording_stopped": "녹음 중지됨",
-              "registered": "등록됨"
+              "registered": "등록됨",
+              "assist_rejected": "Assist 거부됨"
             }
           }
         }
@@ -270,6 +271,18 @@
         "hangup_on_end": {
           "name": "종료 시 끊기",
           "description": "Assist 세션 종료 시 통화를 끊습니다."
+        },
+        "allowed_callers": {
+          "name": "허용 발신자",
+          "description": "Assist를 시작할 수 있는 발신자 번호. 생략하면 제한 없음. Caller ID는 스푸핑될 수 있으므로 도어락 intent에는 PIN을 함께 쓰세요."
+        },
+        "contacts_only": {
+          "name": "연락처만 허용",
+          "description": "sip_contacts.json에 있는 발신자만 Assist를 시작할 수 있습니다. 허용 발신자와 함께 쓰면 둘 다 맞아야 합니다."
+        },
+        "pin": {
+          "name": "PIN",
+          "description": "선택 DTMF PIN. Assist 시작 전에 입력해야 합니다(# 또는 PIN 길이). 실패·타임아웃은 sip_assist_rejected를 내고 intent는 실행하지 않습니다."
         }
       }
     }

--- a/custom_components/sip/translations/ru.json
+++ b/custom_components/sip/translations/ru.json
@@ -121,7 +121,8 @@
               "ended": "Вызов завершён",
               "recording_started": "Запись начата",
               "recording_stopped": "Запись остановлена",
-              "registered": "Зарегистрирован"
+              "registered": "Зарегистрирован",
+              "assist_rejected": "Assist отклонён"
             }
           }
         }
@@ -270,6 +271,18 @@
         "hangup_on_end": {
           "name": "Завершить вызов",
           "description": "Завершить вызов по окончании сессии Assist."
+        },
+        "allowed_callers": {
+          "name": "Разрешённые номера",
+          "description": "Номера, которым можно запускать Assist. Если не указано — без ограничений. Caller ID можно подделать; для замка используйте PIN."
+        },
+        "contacts_only": {
+          "name": "Только контакты",
+          "description": "Assist могут запускать только номера из sip_contacts.json. Вместе с разрешёнными номерами должны совпасть оба условия."
+        },
+        "pin": {
+          "name": "PIN",
+          "description": "Необязательный DTMF PIN. Нужно ввести до запуска Assist (# или длина PIN). Ошибка или таймаут вызывают sip_assist_rejected, intent не выполняется."
         }
       }
     }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -762,8 +762,11 @@ Assist 경로의 별 문제였고 이미 가드했다. 수신 지터는 이 이�
    둘 다 켜면 교집합이다. 옵션을 생략하면 기존처럼 전원 허용.
 2. 선택 `pin` DTMF 게이트. `#` 또는 PIN 길이로 제출, 15초 타임아웃. 실패·끊김·
    타임아웃은 intent를 실행하지 않고 `pin_mismatch` / `pin_timeout`을 낸다.
-   PIN은 로그·이벤트에 넣지 않는다. 게이트는 `handle_start_assist`에만 있고
-   IVR `assist: true`는 통과하지 않는다.
+   PIN은 로그·이벤트에 넣지 않는다. `pin_collector`가 활성인 동안 DTMF는
+   수집기에만 들어가고 `sip_dtmf_digit`·logbook·IVR로 나가지 않는다.
+   게이트는 `handle_start_assist`에만 있고 IVR `assist: true`는 통과하지 않는다.
+   영숫자 내선(`cam2`, `doorbird1`)은 전체 사용자 파트로 비교한다. 전화번호
+   형태일 때만 구분자 제거 후 숫자 문자열로 맞춘다.
 3. README에 권장 경로를 명시: 도어락/보안 intent는 **화이트리스트 + PIN +
    전용 pipeline**. Caller ID 스푸핑을 경고한다.
 
@@ -772,6 +775,8 @@ Assist 경로의 별 문제였고 이미 가드했다. 수신 지터는 이 이�
 
 **추가된 테스트** (`tests/test_assist_gate.py`)
 - `test_normalize_caller_strips_sip_uri`
+- `test_normalize_caller_keeps_alphanumeric_user_part`
+- `test_alphanumeric_callers_do_not_collide_on_trailing_digit`
 - `test_caller_allowed_when_no_restriction`
 - `test_empty_allow_list_rejects_everyone`
 - `test_caller_rejected_when_not_on_allow_list`
@@ -782,6 +787,7 @@ Assist 경로의 별 문제였고 이미 가드했다. 수신 지터는 이 이�
 - `test_pin_collector_rejects_mismatch_without_exposing_digits`
 - `test_pin_collector_times_out`
 - `test_pin_collector_fail_is_mismatch`
+- `test_take_pin_digit_consumes_without_exposing`
 - `test_start_assist_rejects_unknown_caller`
 - `test_start_assist_allows_listed_caller`
 - `test_start_assist_pin_mismatch_does_not_start`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -751,22 +751,41 @@ Assist 경로의 별 문제였고 이미 가드했다. 수신 지터는 이 이�
 
 ## P4 — 보안 게이트
 
-### [ ] P4-1. Assist 발신자 인가
+### [x] P4-1. Assist 발신자 인가
 
 **근거** §1.3-8. `sip.start_assist`에 발신자 제한이 전무하다. Caller ID는 스푸핑
 가능하므로 화이트리스트만으로도 부족하다.
 
 **작업**
-1. `sip.start_assist`에 발신자 허용 목록 옵션을 추가한다(contacts 재사용 또는 명시 목록).
-   목록에 없으면 Assist를 시작하지 않고 이벤트로 거절 사실을 알린다.
-2. DTMF PIN 게이트를 선택 옵션으로 제공한다. IVR에 이미 `input: pin`이 있으므로
-   내부적으로 재사용 가능하다.
-3. **문서에 권장 경로를 명시한다**: 도어락/보안 관련 intent를 쓸 경우
-   "화이트리스트 + PIN + 전용 pipeline"을 기본으로 안내. 기본값이 없으면 사용자가
-   그냥 열어둔다.
+1. `sip.start_assist`에 `allowed_callers`와 `contacts_only`를 추가했다. 목록에
+   없으면 Assist를 시작하지 않고 `sip_assist_rejected`(`not_allowed`)를 낸다.
+   둘 다 켜면 교집합이다. 옵션을 생략하면 기존처럼 전원 허용.
+2. 선택 `pin` DTMF 게이트. `#` 또는 PIN 길이로 제출, 15초 타임아웃. 실패·끊김·
+   타임아웃은 intent를 실행하지 않고 `pin_mismatch` / `pin_timeout`을 낸다.
+   PIN은 로그·이벤트에 넣지 않는다. 게이트는 `handle_start_assist`에만 있고
+   IVR `assist: true`는 통과하지 않는다.
+3. README에 권장 경로를 명시: 도어락/보안 intent는 **화이트리스트 + PIN +
+   전용 pipeline**. Caller ID 스푸핑을 경고한다.
 
 **수용 기준** 허용 목록에 없는 발신자가 `start_assist`에 도달하면 세션이 시작되지 않고
 거절 이벤트가 발생한다. PIN 옵션 활성 시 PIN 통과 전에는 intent가 실행되지 않는다.
+
+**추가된 테스트** (`tests/test_assist_gate.py`)
+- `test_normalize_caller_strips_sip_uri`
+- `test_caller_allowed_when_no_restriction`
+- `test_empty_allow_list_rejects_everyone`
+- `test_caller_rejected_when_not_on_allow_list`
+- `test_caller_rejected_when_contacts_only_and_unknown`
+- `test_caller_allow_list_and_contacts_only_intersect`
+- `test_pin_collector_accepts_matching_digits`
+- `test_pin_collector_hash_submits_early`
+- `test_pin_collector_rejects_mismatch_without_exposing_digits`
+- `test_pin_collector_times_out`
+- `test_pin_collector_fail_is_mismatch`
+- `test_start_assist_rejects_unknown_caller`
+- `test_start_assist_allows_listed_caller`
+- `test_start_assist_pin_mismatch_does_not_start`
+- `test_start_assist_pin_ok_starts_assist`
 
 ---
 

--- a/tests/test_assist_gate.py
+++ b/tests/test_assist_gate.py
@@ -1,0 +1,306 @@
+"""Assist allow-list and PIN gate (P4-1)."""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import voluptuous as vol
+
+from test_pure import _assist_ctx, _load_component_module
+
+gate = _load_component_module("assist_gate")
+
+
+def test_normalize_caller_strips_sip_uri():
+    assert gate.normalize_caller("sip:100@pbx.local") == "100"
+    assert gate.normalize_caller("<sip:101@192.0.2.1>") == "101"
+    assert gate.normalize_caller(" 102 ") == "102"
+    assert gate.normalize_caller("+82-10-1234-5678") == "+821012345678"
+
+
+def test_caller_allowed_when_no_restriction():
+    assert gate.caller_is_allowed("sip:999@pbx") is True
+    assert gate.caller_is_allowed("") is True
+
+
+def test_empty_allow_list_rejects_everyone():
+    assert gate.caller_is_allowed("100", allowed_callers=[]) is False
+    assert gate.caller_is_allowed("", allowed_callers=[]) is False
+
+
+def test_caller_rejected_when_not_on_allow_list():
+    assert (
+        gate.caller_is_allowed(
+            "sip:200@pbx",
+            allowed_callers=["100", "101"],
+        )
+        is False
+    )
+    assert (
+        gate.caller_is_allowed(
+            "sip:100@pbx",
+            allowed_callers=["100", "101"],
+        )
+        is True
+    )
+
+
+def test_caller_rejected_when_contacts_only_and_unknown():
+    contacts = {"100": "Dad", "102": {"name": "Gate", "auto_answer": True}}
+    assert (
+        gate.caller_is_allowed(
+            "200",
+            contacts=contacts,
+            contacts_only=True,
+        )
+        is False
+    )
+    assert (
+        gate.caller_is_allowed(
+            "sip:102@pbx",
+            contacts=contacts,
+            contacts_only=True,
+        )
+        is True
+    )
+
+
+def test_caller_allow_list_and_contacts_only_intersect():
+    contacts = {"100": "Dad", "101": "Mom"}
+    assert (
+        gate.caller_is_allowed(
+            "100",
+            allowed_callers=["100", "200"],
+            contacts=contacts,
+            contacts_only=True,
+        )
+        is True
+    )
+    assert (
+        gate.caller_is_allowed(
+            "200",
+            allowed_callers=["100", "200"],
+            contacts=contacts,
+            contacts_only=True,
+        )
+        is False
+    )
+
+
+def test_pin_collector_accepts_matching_digits():
+    async def run():
+        collector = gate.PinCollector("1234")
+        collector.handle_digit("1")
+        collector.handle_digit("2")
+        collector.handle_digit("3")
+        collector.handle_digit("4")
+        return await collector.wait(timeout=1)
+
+    assert asyncio.run(run()) == "ok"
+
+
+def test_pin_collector_hash_submits_early():
+    async def run():
+        collector = gate.PinCollector("1234")
+        collector.handle_digit("1")
+        collector.handle_digit("#")
+        return await collector.wait(timeout=1)
+
+    assert asyncio.run(run()) == gate.REASON_PIN_MISMATCH
+
+
+def test_pin_collector_rejects_mismatch_without_exposing_digits():
+    async def run():
+        collector = gate.PinCollector("12")
+        collector.handle_digit("9")
+        collector.handle_digit("9")
+        result = await collector.wait(timeout=1)
+        assert not hasattr(result, "pin")
+        return result
+
+    assert asyncio.run(run()) == gate.REASON_PIN_MISMATCH
+
+
+def test_pin_collector_times_out():
+    async def run():
+        collector = gate.PinCollector("12")
+        return await collector.wait(timeout=0.05)
+
+    assert asyncio.run(run()) == gate.REASON_PIN_TIMEOUT
+
+
+def test_pin_collector_fail_is_mismatch():
+    async def run():
+        collector = gate.PinCollector("12")
+        collector.fail()
+        return await collector.wait(timeout=1)
+
+    assert asyncio.run(run()) == gate.REASON_PIN_MISMATCH
+
+
+def _load_sip_init():
+    """Load __init__.py with a cv stub that includes ensure_list (P4-1 schema)."""
+    _assist_ctx()
+    helpers = sys.modules["homeassistant.helpers"]
+    cv_stub = types.SimpleNamespace(
+        boolean=bool,
+        match_all=lambda value: value,
+        positive_int=int,
+        string=str,
+        ensure_list=lambda v: list(v) if isinstance(v, (list, tuple)) else [v],
+        make_entity_service_schema=lambda schema: vol.Schema(schema),
+    )
+    helpers.config_validation = cv_stub
+    sys.modules["homeassistant.helpers.config_validation"] = cv_stub
+    service_stub = types.ModuleType("homeassistant.helpers.service")
+    service_stub.async_extract_config_entry_ids = AsyncMock()
+    sys.modules["homeassistant.helpers.service"] = service_stub
+
+    module_name = "custom_components.sip._p4_1_init_test"
+    existing = sys.modules.get(module_name)
+    if existing is not None and hasattr(existing, "async_register_services"):
+        return existing
+    sys.modules.pop(module_name, None)
+
+    component = os.path.join(
+        os.path.dirname(__file__), "..", "custom_components", "sip"
+    )
+    spec = importlib.util.spec_from_file_location(
+        module_name, os.path.join(os.path.abspath(component), "__init__.py")
+    )
+    integration = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = integration
+    spec.loader.exec_module(integration)
+    return integration
+
+
+def _rejected_events(hass):
+    return [
+        call.args[1]
+        for call in hass.bus.async_fire.call_args_list
+        if call.args and call.args[0] == "sip_assist_rejected"
+    ]
+
+
+async def _register_start_assist(integration, *, caller, contacts=None):
+    trigger_assist = AsyncMock()
+    entry = MagicMock()
+    entry.domain = "sip"
+    entry.entry_id = "entry-1"
+    entry.state.value = "loaded"
+    entry.runtime_data = {
+        "trigger_assist_fn": trigger_assist,
+        "call_number": caller,
+        "config": types.SimpleNamespace(username="100"),
+        "contacts": contacts or {},
+        "pin_collector": None,
+    }
+    hass = MagicMock()
+    hass.services.has_service.return_value = False
+    hass.config_entries.async_entries.return_value = [entry]
+    hass.config_entries.async_get_entry.return_value = entry
+    integration.async_extract_config_entry_ids = AsyncMock(return_value={"entry-1"})
+    await integration.async_register_services(hass)
+    handler = next(
+        call.args[2]
+        for call in hass.services.async_register.call_args_list
+        if call.args[:2] == ("sip", "start_assist")
+    )
+    return hass, trigger_assist, entry, handler
+
+
+def test_start_assist_rejects_unknown_caller():
+    integration = _load_sip_init()
+
+    async def run():
+        hass, trigger, _entry, handler = await _register_start_assist(
+            integration, caller="sip:200@pbx"
+        )
+        data = integration.SERVICE_ASSIST_SCHEMA({"allowed_callers": ["100"]})
+        await handler(types.SimpleNamespace(data=data))
+        return hass, trigger
+
+    hass, trigger = asyncio.run(run())
+    trigger.assert_not_awaited()
+    rejected = _rejected_events(hass)
+    assert len(rejected) == 1
+    assert rejected[0]["caller"] == "sip:200@pbx"
+    assert rejected[0]["reason"] == gate.REASON_NOT_ALLOWED
+    assert "pin" not in rejected[0]
+
+
+def test_start_assist_allows_listed_caller():
+    integration = _load_sip_init()
+
+    async def run():
+        hass, trigger, _entry, handler = await _register_start_assist(
+            integration, caller="sip:100@pbx"
+        )
+        data = integration.SERVICE_ASSIST_SCHEMA({"allowed_callers": ["100"]})
+        await handler(types.SimpleNamespace(data=data))
+        return hass, trigger
+
+    hass, trigger = asyncio.run(run())
+    trigger.assert_awaited_once()
+    assert _rejected_events(hass) == []
+
+
+def test_start_assist_pin_mismatch_does_not_start():
+    integration = _load_sip_init()
+
+    async def run():
+        hass, trigger, entry, handler = await _register_start_assist(
+            integration, caller="100"
+        )
+        data = integration.SERVICE_ASSIST_SCHEMA({"pin": "1234"})
+        task = asyncio.create_task(handler(types.SimpleNamespace(data=data)))
+        collector = None
+        for _ in range(50):
+            collector = entry.runtime_data.get("pin_collector")
+            if collector is not None:
+                break
+            await asyncio.sleep(0)
+        assert collector is not None
+        for digit in "9999":
+            collector.handle_digit(digit)
+        await task
+        return hass, trigger
+
+    hass, trigger = asyncio.run(run())
+    trigger.assert_not_awaited()
+    rejected = _rejected_events(hass)
+    assert len(rejected) == 1
+    assert rejected[0]["reason"] == gate.REASON_PIN_MISMATCH
+    assert "1234" not in str(rejected[0])
+    assert "9999" not in str(rejected[0])
+
+
+def test_start_assist_pin_ok_starts_assist():
+    integration = _load_sip_init()
+
+    async def run():
+        hass, trigger, entry, handler = await _register_start_assist(
+            integration, caller="100"
+        )
+        data = integration.SERVICE_ASSIST_SCHEMA({"pin": "1234"})
+        task = asyncio.create_task(handler(types.SimpleNamespace(data=data)))
+        collector = None
+        for _ in range(50):
+            collector = entry.runtime_data.get("pin_collector")
+            if collector is not None:
+                break
+            await asyncio.sleep(0)
+        assert collector is not None
+        for digit in "1234":
+            collector.handle_digit(digit)
+        await task
+        return hass, trigger
+
+    hass, trigger = asyncio.run(run())
+    trigger.assert_awaited_once()
+    assert _rejected_events(hass) == []
+

--- a/tests/test_assist_gate.py
+++ b/tests/test_assist_gate.py
@@ -22,6 +22,27 @@ def test_normalize_caller_strips_sip_uri():
     assert gate.normalize_caller("+82-10-1234-5678") == "+821012345678"
 
 
+def test_normalize_caller_keeps_alphanumeric_user_part():
+    assert gate.normalize_caller("cam2") == "cam2"
+    assert gate.normalize_caller("Doorbird1") == "doorbird1"
+    assert gate.normalize_caller("sip:kitchen1@pbx") == "kitchen1"
+    assert gate.normalize_caller("<sip:CAM2@192.0.2.1>") == "cam2"
+
+
+def test_alphanumeric_callers_do_not_collide_on_trailing_digit():
+    assert gate.caller_is_allowed("cam2", allowed_callers=["door2"]) is False
+    assert gate.caller_is_allowed("cam2", allowed_callers=["cam2"]) is True
+    assert gate.caller_is_allowed("sip:CAM2@pbx", allowed_callers=["cam2"]) is True
+    contacts = {"door2": "Gate", "kitchen1": "Kitchen"}
+    assert (
+        gate.caller_is_allowed("cam2", contacts=contacts, contacts_only=True) is False
+    )
+    assert (
+        gate.caller_is_allowed("kitchen1", contacts=contacts, contacts_only=True)
+        is True
+    )
+
+
 def test_caller_allowed_when_no_restriction():
     assert gate.caller_is_allowed("sip:999@pbx") is True
     assert gate.caller_is_allowed("") is True
@@ -140,6 +161,17 @@ def test_pin_collector_fail_is_mismatch():
         return await collector.wait(timeout=1)
 
     assert asyncio.run(run()) == gate.REASON_PIN_MISMATCH
+
+
+def test_take_pin_digit_consumes_without_exposing():
+    async def run():
+        collector = gate.PinCollector("47")
+        assert gate.take_pin_digit(collector, "4") is True
+        assert gate.take_pin_digit(collector, "7") is True
+        return await collector.wait(timeout=1)
+
+    assert asyncio.run(run()) == "ok"
+    assert gate.take_pin_digit(None, "4") is False
 
 
 def _load_sip_init():

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -3705,6 +3705,7 @@ def test_start_assist_service_accepts_and_forwards_prompts():
         match_all=lambda value: value,
         positive_int=int,
         string=str,
+        ensure_list=lambda v: list(v) if isinstance(v, (list, tuple)) else [v],
         make_entity_service_schema=lambda schema: vol.Schema(schema),
     )
     helpers.config_validation = cv_stub


### PR DESCRIPTION
## Summary
- `sip.start_assist` can restrict callers with `allowed_callers` and/or `contacts_only` (intersection when both are set). Omitted options keep the previous open behaviour.
- Optional DTMF `pin` must match before Assist starts. Mismatch, hangup, or a 15 s timeout fires `sip_assist_rejected` and does not run intents. The PIN is never logged or put on the event.
- README documents the door-lock path: allow-list + PIN + a dedicated pipeline. Caller ID spoofing is called out. IVR `assist: true` is not gated here.

## Test plan
- [x] `python -m pytest tests/` (253 passed on Python 3.12)
- [x] `ruff check custom_components/ tests/`
- [ ] Call `sip.start_assist` with `allowed_callers` that does not include the current caller — Assist must not start, `sip_assist_rejected` / `not_allowed` must fire
- [ ] With `pin` set, enter the wrong digits — Assist must not start, reason `pin_mismatch`; enter the PIN — Assist starts
- [ ] Existing automations with no new fields still start Assist for any caller


Made with [Cursor](https://cursor.com)