### PR TITLE
feat: run Assist intents as a per-account HA user (P4-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The session ends when:
 - `contacts_only` *(Optional)*: Only callers listed in `sip_contacts.json` may start Assist (default: `false`). Combined with `allowed_callers`, the caller must match **both**.
 - `pin` *(Optional)*: DTMF PIN collected before Assist starts. The caller enters the digits and either presses `#` or matches the PIN length (15 s timeout). Failed, hung-up, or timed-out attempts fire `sip_assist_rejected` and do **not** run intents. While the PIN is collected, digits are not logged and `sip_dtmf_digit` is not fired, so the PIN cannot be reconstructed from Logbook or automations.
 
-> **Caller ID can be spoofed.** An allow-list alone is not a security boundary. For door-lock or other security intents, use **allow-list + PIN + a dedicated Assist pipeline** that only exposes those intents. IVR `assist: true` does not use this gate — give that menu its own PIN if needed. SIP INFO DTMF digits can still appear in DEBUG logs and opt-in SIP traces (`Signal=` in INFO bodies); do not attach those logs to an issue if a PIN was entered.
+> **Caller ID can be spoofed.** An allow-list alone is not a security boundary. For door-lock or other security intents, use **allow-list + PIN + a dedicated Assist pipeline** that only exposes those intents, and grant the `SIP Assist ({extension})` user access only to those entities. IVR `assist: true` does not use this gate — give that menu its own PIN if needed. SIP INFO DTMF digits can still appear in DEBUG logs and opt-in SIP traces (`Signal=` in INFO bodies); do not attach those logs to an issue if a PIN was entered.
 
 ```yaml
   - service: sip.start_assist
@@ -501,6 +501,8 @@ On a noisy or narrowband (G.711) line, the assistant may react to line noise or 
       noise_suppression: 2
       turn_tone: true
 ```
+
+Each SIP account gets a Home Assistant system user named `SIP Assist ({extension})` in the Users group (the same pattern as the core VoIP integration). Assist intents run as that user and reuse one `Context` for the whole session, so Logbook can attribute those actions to that call. Grant this user access to the entities the phone should control. Removing the SIP entry deletes the user.
 
 ---
 

--- a/custom_components/sip/__init__.py
+++ b/custom_components/sip/__init__.py
@@ -25,6 +25,7 @@ from .assist_gate import (
     caller_is_allowed,
     take_pin_digit,
 )
+from .assist_user import ensure_assist_user, remove_assist_user
 from .const import (
     CONF_CALLER_ID,
     CONF_DOMAIN,
@@ -237,6 +238,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Load contacts asynchronously from file to avoid blocking event loop on startup
     contacts = await hass.async_add_executor_job(load_contacts, hass)
+    assist_user_id = await ensure_assist_user(hass, entry)
 
     entry.runtime_data = {
         "client": None,
@@ -579,6 +581,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hangup_on_end=hangup_on_end,
             stop_audio_fn=client.stop_audio,
             media_playing_fn=lambda: client.media_playing,
+            user_id=assist_user_id,
+            device_id=_sip_device_id(hass, entry.entry_id),
         )
 
         def on_assist_done() -> None:
@@ -672,6 +676,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     pass
 
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Delete the Assist system user created for this account."""
+    await remove_assist_user(hass, entry)
 
 
 async def async_register_services(hass: HomeAssistant) -> None:

--- a/custom_components/sip/assist.py
+++ b/custom_components/sip/assist.py
@@ -210,6 +210,8 @@ class AssistBridge(AudioSink):
         hangup_on_end: bool = False,
         stop_audio_fn: Callable[..., None] | None = None,
         media_playing_fn: Callable[[], bool] | None = None,
+        user_id: str | None = None,
+        device_id: str | None = None,
     ) -> None:
         """Initialize the Assist bridge."""
         self.hass = hass
@@ -232,6 +234,8 @@ class AssistBridge(AudioSink):
         self.turn_tone = turn_tone
         self.stop_audio_fn = stop_audio_fn
         self.media_playing_fn = media_playing_fn
+        self._context = Context(user_id=user_id)
+        self._device_id = device_id
 
         if barge_in and MicroVad is None:
             LOGGER.warning(
@@ -511,7 +515,7 @@ class AssistBridge(AudioSink):
                 try:
                     await async_pipeline_from_audio_stream(
                         self.hass,
-                        context=Context(),
+                        context=self._context,
                         event_callback=self._on_pipeline_event,
                         stt_metadata=stt_metadata,
                         stt_stream=self.audio_stream,
@@ -521,6 +525,7 @@ class AssistBridge(AudioSink):
                         start_stage=PipelineStage.STT,
                         end_stage=PipelineStage.TTS,
                         conversation_extra_system_prompt=self.system_prompt,
+                        device_id=self._device_id,
                     )
                 finally:
                     self._listening = False
@@ -596,7 +601,7 @@ class AssistBridge(AudioSink):
             pipeline_input = PipelineInput(
                 run=PipelineRun(
                     self.hass,
-                    context=Context(),
+                    context=self._context,
                     pipeline=pipeline,
                     start_stage=PipelineStage.INTENT,
                     end_stage=PipelineStage.TTS,
@@ -605,6 +610,7 @@ class AssistBridge(AudioSink):
                 session=session,
                 intent_input=self.initial_prompt,
                 conversation_extra_system_prompt=self.system_prompt,
+                device_id=self._device_id,
             )
             await pipeline_input.validate()
             await pipeline_input.execute()

--- a/custom_components/sip/assist_user.py
+++ b/custom_components/sip/assist_user.py
@@ -1,0 +1,47 @@
+"""Home Assistant user that owns Assist intent execution for a SIP account."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_ASSIST_USER, CONF_USERNAME
+
+_USERS_GROUP = "system-users"
+
+
+async def ensure_assist_user(hass: HomeAssistant, entry: ConfigEntry) -> str:
+    """Return a user id for Assist contexts, creating a system user if needed.
+
+    Follows core ``voip``: a Users-group system user so intent service calls
+    have a logbook subject and are not executed as an empty Context.
+    """
+    try:
+        from homeassistant.auth.const import GROUP_ID_USER
+    except ImportError:
+        GROUP_ID_USER = _USERS_GROUP
+
+    existing_id = entry.data.get(CONF_ASSIST_USER)
+    if existing_id:
+        user = await hass.auth.async_get_user(existing_id)
+        if user is not None:
+            return existing_id
+
+    username = entry.data.get(CONF_USERNAME) or entry.entry_id
+    created = await hass.auth.async_create_system_user(
+        f"SIP Assist ({username})",
+        group_ids=[GROUP_ID_USER],
+    )
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, CONF_ASSIST_USER: created.id}
+    )
+    return created.id
+
+
+async def remove_assist_user(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Delete the system user created for this entry, if it still exists."""
+    user_id = entry.data.get(CONF_ASSIST_USER)
+    if not user_id:
+        return
+    user = await hass.auth.async_get_user(user_id)
+    if user is not None:
+        await hass.auth.async_remove_user(user)

--- a/custom_components/sip/config_flow.py
+++ b/custom_components/sip/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from collections.abc import Mapping
 import asyncio
 import voluptuous as vol
 
@@ -93,6 +94,16 @@ def _suggested_rtp_port(hass: HomeAssistant) -> int:
     while port in used:
         port += 2  # RTP/RTCP pair convention
     return port
+
+
+def merge_reconfigure_data(
+    entry_data: Mapping[str, Any], user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply form fields onto existing entry data.
+
+    Reconfigure must not drop keys the form does not collect (``assist_user``).
+    """
+    return {**entry_data, **user_input}
 
 
 async def async_validate_sip_registration(
@@ -215,7 +226,8 @@ class SipConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = "cannot_connect"
             else:
                 return self.async_update_reload_and_abort(
-                    reconfigure_entry, data=user_input
+                    reconfigure_entry,
+                    data=merge_reconfigure_data(reconfigure_entry.data, user_input),
                 )
 
         return self.async_show_form(

--- a/custom_components/sip/const.py
+++ b/custom_components/sip/const.py
@@ -17,6 +17,7 @@ CONF_OUTBOUND_PROXY = "outbound_proxy"
 CONF_AUTH_USERNAME = "authentication_username"
 CONF_MEDIA_TIMEOUT = "media_timeout"
 CONF_MAX_CALL_DURATION = "max_call_duration"
+CONF_ASSIST_USER = "assist_user"
 
 # Defaults
 DEFAULT_PORT = 5060

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -795,19 +795,34 @@ Assist 경로의 별 문제였고 이미 가드했다. 수신 지터는 이 이�
 
 ---
 
-### [ ] P4-2. Assist 실행 주체 부여
+### [x] P4-2. Assist 실행 주체 부여
 
-**근거** §1.3-8. `assist.py:388`, `:473`의 빈 `Context()` 때문에 전화 발신자가 모든
-intent를 무제한 권한으로 실행하고 감사 로그에 주체가 없다.
+**근거** §1.3-8. 빈 `Context()` 때문에 전화 발신자가 모든 intent를 무제한 권한으로
+실행하고 감사 로그에 주체가 없었다.
 
-**작업** `Context`에 주체를 부여하는 방식을 조사해 결정한다. 후보:
-- config entry에 연결된 전용 HA 사용자를 지정하게 하고 그 `user_id`로 Context를 만든다
-- 최소한 `Context(id=...)`에 통화 식별자를 넣어 logbook에서 추적 가능하게 한다
+**조사 결과**
+- Assist pipeline은 받은 `Context`를 `conversation.async_converse`로 그대로 넘긴다.
+  `user_id`가 있으면 그 사용자로 서비스가 실행되고 logbook에 남는다. `id`가 같으면
+  한 세션의 턴이 한 원인으로 묶인다.
+- Core `voip`은 설정에서 사용자를 고르지 않고 `hass.auth.async_create_system_user`
+  (`GROUP_ID_USER`)로 "Voice over IP" 사용자를 만든 뒤 `Context(user_id=...)`를 쓴다.
+- 설정 UI에 사용자 선택을 넣으면 기존 엔트리가 깨지고, `Context(id=...)`만 넣으면
+  logbook 상관은 되지만 권한은 여전히 비어 있는 주체(관리자급)다.
 
-조사 결과를 이 문서에 기록하고, 권한 모델이 불가능하면 "이 조합은 권장하지 않음"을
-문서에 명시하는 것으로 대체한다.
+**작업** core `voip`과 같이 계정마다 `SIP Assist ({내선})` 시스템 사용자를 만들고
+Assist 세션당 `Context`를 하나 만들어 모든 턴·initial_prompt에 재사용한다.
+pipeline에는 SIP `device_id`도 넘긴다. 엔트리 삭제 시 사용자를 제거한다.
 
-**수용 기준** Assist가 실행한 서비스 호출이 logbook에서 특정 통화로 귀속된다.
+**수용 기준** Assist가 실행한 서비스 호출이 logbook에서 해당 SIP 계정 사용자와
+그 Assist 세션(통화) context로 귀속된다.
+
+**추가된 테스트** (`tests/test_assist_context.py`)
+- `test_ensure_assist_user_reuses_existing`
+- `test_ensure_assist_user_creates_when_missing`
+- `test_remove_assist_user_deletes_existing`
+- `test_remove_assist_user_skips_when_absent`
+- `test_assist_reuses_session_context_and_forwards_user`
+- `test_assist_initial_prompt_uses_same_context`
 
 ---
 
@@ -918,8 +933,10 @@ reconfigure에서 기존 비밀번호가 평문으로 표시되지 않게 한다
 
 1. **P0-3의 기본값**: media timeout 30초 / max duration 3600초가 적절한가?
    인터폰 용도에서는 더 짧아야 할 수 있다.
-2. **P4-2의 권한 모델**: Assist 실행에 전용 HA 사용자를 요구하는 것이 UX상 받아들여지나?
-   대안은 "권장하지 않음"을 문서화하는 것뿐이다.
+2. **P4-2의 권한 모델**: 전용 HA 사용자를 설정에서 고르게 하지 않는다. core `voip`과
+   같이 계정마다 Users 그룹 시스템 사용자를 자동 생성하고, Assist 세션은 그
+   `user_id`와 세션당 하나의 `Context`를 재사용한다. 권한은 그 사용자에게
+   엔티티 접근을 부여하는 쪽으로 문서화한다.
 3. **P2-2의 녹음 파일 경로 제한**: HA 설정 디렉터리 밖 쓰기를 막을 것인가?
    막으면 기존 사용자의 자동화가 깨질 수 있다.
 4. **P5-1의 PBX 검증 범위**: 실제로 Asterisk/FreePBX를 컨테이너로 띄워 CI에서 E2E를

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -812,6 +812,7 @@ Assist 경로의 별 문제였고 이미 가드했다. 수신 지터는 이 이�
 **작업** core `voip`과 같이 계정마다 `SIP Assist ({내선})` 시스템 사용자를 만들고
 Assist 세션당 `Context`를 하나 만들어 모든 턴·initial_prompt에 재사용한다.
 pipeline에는 SIP `device_id`도 넘긴다. 엔트리 삭제 시 사용자를 제거한다.
+Reconfigure는 폼 필드를 기존 `entry.data`에 병합해 `assist_user`가 지워지지 않게 한다.
 
 **수용 기준** Assist가 실행한 서비스 호출이 logbook에서 해당 SIP 계정 사용자와
 그 Assist 세션(통화) context로 귀속된다.
@@ -823,6 +824,7 @@ pipeline에는 SIP `device_id`도 넘긴다. 엔트리 삭제 시 사용자를 �
 - `test_remove_assist_user_skips_when_absent`
 - `test_assist_reuses_session_context_and_forwards_user`
 - `test_assist_initial_prompt_uses_same_context`
+- `test_reconfigure_preserves_assist_user`
 
 ---
 

--- a/tests/test_assist_context.py
+++ b/tests/test_assist_context.py
@@ -1,0 +1,161 @@
+"""Assist pipeline Context subject (P4-2)."""
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from test_pure import _assist_ctx, _load_component_module, _run_bridge_session
+
+assist_user = _load_component_module("assist_user")
+
+
+class _Ctx:
+    def __init__(self, user_id=None, parent_id=None, id=None):
+        self.user_id = user_id
+        self.parent_id = parent_id
+        self.id = id or "generated"
+
+
+def test_ensure_assist_user_reuses_existing():
+    async def run():
+        hass = types.SimpleNamespace(
+            auth=types.SimpleNamespace(
+                async_get_user=AsyncMock(return_value=MagicMock(id="keep-me")),
+                async_create_system_user=AsyncMock(),
+            ),
+            config_entries=MagicMock(),
+        )
+        entry = MagicMock()
+        entry.data = {"username": "100", "assist_user": "keep-me"}
+        return await assist_user.ensure_assist_user(hass, entry)
+
+    assert asyncio.run(run()) == "keep-me"
+
+
+def test_ensure_assist_user_creates_when_missing():
+    async def run():
+        create = AsyncMock(return_value=MagicMock(id="new-user"))
+        hass = types.SimpleNamespace(
+            auth=types.SimpleNamespace(
+                async_get_user=AsyncMock(return_value=None),
+                async_create_system_user=create,
+            ),
+            config_entries=MagicMock(),
+        )
+        entry = MagicMock()
+        entry.data = {"username": "100"}
+        uid = await assist_user.ensure_assist_user(hass, entry)
+        create.assert_awaited_once()
+        assert create.call_args.args[0] == "SIP Assist (100)"
+        hass.config_entries.async_update_entry.assert_called_once()
+        updated = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert updated["assist_user"] == "new-user"
+        return uid
+
+    assert asyncio.run(run()) == "new-user"
+
+
+def test_remove_assist_user_deletes_existing():
+    async def run():
+        user = MagicMock()
+        remove = AsyncMock()
+        hass = types.SimpleNamespace(
+            auth=types.SimpleNamespace(
+                async_get_user=AsyncMock(return_value=user),
+                async_remove_user=remove,
+            )
+        )
+        entry = MagicMock()
+        entry.data = {"assist_user": "gone"}
+        await assist_user.remove_assist_user(hass, entry)
+        remove.assert_awaited_once_with(user)
+
+    asyncio.run(run())
+
+
+def test_remove_assist_user_skips_when_absent():
+    async def run():
+        remove = AsyncMock()
+        hass = types.SimpleNamespace(
+            auth=types.SimpleNamespace(
+                async_get_user=AsyncMock(),
+                async_remove_user=remove,
+            )
+        )
+        entry = MagicMock()
+        entry.data = {}
+        await assist_user.remove_assist_user(hass, entry)
+        remove.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_assist_reuses_session_context_and_forwards_user():
+    assist_mod, mock_ap, PET, PE = _assist_ctx()
+    seen = []
+
+    async def mock_pipeline(hass, **kwargs):
+        seen.append(kwargs)
+        kwargs["event_callback"](PE(PET.ERROR, {"code": "stt-no-text-recognized"}))
+
+    mock_ap.async_pipeline_from_audio_stream.side_effect = mock_pipeline
+
+    with patch.object(assist_mod, "Context", _Ctx):
+        bridge = assist_mod.AssistBridge(
+            MagicMock(),
+            play_source_fn=MagicMock(),
+            on_done_fn=MagicMock(),
+            user_id="user-sip",
+            device_id="dev-1",
+            max_silent_turns=2,
+        )
+        _run_bridge_session(bridge)
+
+    assert len(seen) == 2
+    assert seen[0]["context"] is seen[1]["context"]
+    assert seen[0]["context"].user_id == "user-sip"
+    assert seen[0]["device_id"] == "dev-1"
+    assert seen[1]["device_id"] == "dev-1"
+
+
+def test_assist_initial_prompt_uses_same_context():
+    assist_mod, mock_ap, PET, PE = _assist_ctx()
+    from test_pure import _initial_prompt_doubles
+
+    audio_calls = []
+    (
+        pipeline_runs,
+        pipeline_inputs,
+        fake_run,
+        fake_input,
+        fake_chat_session,
+    ) = _initial_prompt_doubles(PET, PE, (PET.ERROR, {"code": "intent-failed"}))
+
+    async def mock_audio_pipeline(hass, **kwargs):
+        audio_calls.append(kwargs)
+
+    mock_ap.async_pipeline_from_audio_stream.reset_mock()
+    mock_ap.async_pipeline_from_audio_stream.side_effect = mock_audio_pipeline
+
+    with (
+        patch.object(assist_mod, "Context", _Ctx),
+        patch.object(assist_mod, "PipelineRun", fake_run),
+        patch.object(assist_mod, "PipelineInput", fake_input),
+        patch.object(assist_mod, "chat_session", fake_chat_session),
+    ):
+        bridge = assist_mod.AssistBridge(
+            MagicMock(),
+            play_source_fn=MagicMock(),
+            on_done_fn=MagicMock(),
+            initial_prompt="Greet the caller",
+            user_id="user-sip",
+            device_id="dev-9",
+            max_turns=1,
+        )
+        _run_bridge_session(bridge)
+
+    assert pipeline_runs[0].kwargs["context"].user_id == "user-sip"
+    assert pipeline_inputs[0].kwargs["device_id"] == "dev-9"
+    assert audio_calls[0]["context"] is pipeline_runs[0].kwargs["context"]
+    assert audio_calls[0]["device_id"] == "dev-9"

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -4931,6 +4931,25 @@ def test_build_schema_reconfigure_prefills_current_entry_values():
     assert markers["outbound_proxy"].default is vol.UNDEFINED
 
 
+def test_reconfigure_preserves_assist_user():
+    merged = config_flow.merge_reconfigure_data(
+        {
+            "username": "1001",
+            "password": "old",
+            "assist_user": "keep-me",
+        },
+        {
+            "username": "1001",
+            "password": "new",
+            "local_rtp_port": 7080,
+        },
+    )
+    assert merged["assist_user"] == "keep-me"
+    assert merged["password"] == "new"
+    assert merged["local_rtp_port"] == 7080
+    assert merged["username"] == "1001"
+
+
 def test_sip_device_id_lookup():
     """_sip_device_id uses async_get_device_by_identifier."""
     import types


### PR DESCRIPTION
## Summary
- Each SIP account gets a Home Assistant system user (`SIP Assist ({extension})`, Users group), matching core `voip`. Assist pipeline runs reuse one `Context(user_id=...)` per session so Logbook can attribute intents to that call.
- The SIP device id is passed into the pipeline. Removing the config entry deletes the system user.
- Config flow is unchanged: the user is created on setup, not picked in the UI. Grant that user access to the entities the phone should control.

## Test plan
- [x] `python -m pytest tests/` (262 passed on Python 3.12)
- [x] `ruff check custom_components/ tests/`
- [ ] After reload, Settings → People shows `SIP Assist ({extension})`
- [ ] `sip.start_assist` then a command like turning on a light — Logbook names the SIP Assist user and groups the session
- [ ] Removing the SIP entry removes that system user


Made with [Cursor](https://cursor.com)