### PR TITLE
docs: add PBX compatibility table and FreePBX Quick Start (P5-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 ![integration usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=usage&suffix=%20installs&cacheSeconds=15600&query=%24.sip.total&url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json)
 
-A native custom integration for Home Assistant to connect directly to a SIP server or PBX (such as FreePBX, Asterisk, or any VoIP provider). It exposes the telephone line as a native media player, allows DTMF control, provides an Interactive Voice Response (IVR) menu engine, and bridges calls directly to Home Assistant's Voice Assist.
+A native custom integration for Home Assistant that **registers as a SIP extension** on an existing PBX. It exposes the telephone line as a media player, sends and receives DTMF, runs IVR menus, and can bridge a call to Home Assistant Voice Assist.
+
+Transport is **SIP over UDP** with **G.711 (PCMU/PCMA) and G.722**. TLS, SRTP, and Opus are not implemented — see [PBX compatibility](#pbx-compatibility).
 
 ## 💬 Feedback & Support
 
@@ -27,9 +29,64 @@ A native custom integration for Home Assistant to connect directly to a SIP serv
    **Manual**: Copy the `custom_components/sip` directory into your Home Assistant `custom_components` folder.
 2. Restart Home Assistant.
 
+## Quick start (FreePBX)
+
+The goal is a registered extension and a two-way call. This path assumes Home Assistant and FreePBX are on the same LAN.
+
+### 1. Create a pjsip extension
+
+In FreePBX: **Applications → Extensions → Add Extension → Add New SIP (chan_pjsip) Extension**.
+
+| Field | Example |
+|-------|---------|
+| User Extension | `1001` |
+| Display Name | `Home Assistant` |
+| Secret | a long random password |
+
+Then on the extension:
+
+1. **Advanced → DTMF Mode**: `RFC 4733` (RFC 2833). hass-sip also accepts SIP INFO if an ATA sends that instead.
+2. **Advanced → Direct Media**: `No`. FreePBX defaults this to `Yes`, which sends a re-INVITE to hairpin RTP. The client answers in-dialog re-INVITE, but pinning media through the PBX is the predictable path — especially with NAT.
+3. **Advanced → Media Encryption**: `No` (SRTP is not implemented).
+4. **Codecs**: enable `g722`, `ulaw`, and `alaw` (order does not have to match; hass-sip offers G.722, then PCMU, then PCMA).
+5. **Submit** and **Apply Config**.
+
+Allow **UDP 5060** from the Home Assistant host to the PBX, and **UDP RTP** from Home Assistant (default starting at `7078`, plus the next even port for RTCP).
+
+### 2. Add the integration
+
+**Settings → Devices & Services → Add Integration → SIP Client**.
+
+- **Server / Host**: FreePBX IP or hostname  
+- **Port**: `5060`  
+- **Username**: `1001`  
+- **Password**: the extension secret  
+
+Leave Domain empty unless your realm is not the server hostname.
+
+### 3. Confirm registration
+
+Wait a few seconds. The **Registration status** sensor should read `registered`, and Logbook should show `sip_registered`. If it stays `unregistered`, check username/password, UDP 5060, and that the extension is `pjsip` (not chan_sip) on a matching transport.
+
+### 4. Place a test call
+
+From another phone on the PBX, dial `1001`. Answer with `sip.answer` (or enable auto-answer for that caller in `sip_contacts.json`). You should get two-way audio; the media player **Call Audio** attribute should become `bidirectional`.
+
+To dial out from Home Assistant:
+
+```yaml
+action: sip.dial
+target:
+  entity_id: media_player.phone_line
+data:
+  number: "1002"
+```
+
+---
+
 ## Configuration
 
-Device setup is done entirely through the Home Assistant UI.
+Device setup is done entirely through the Home Assistant UI. The [Quick start](#quick-start-freepbx) is the shortest path; this list is the field reference.
 
 1. Go to **Settings** > **Devices & Services**.
 2. Click **Add Integration** and search for **SIP Client**.
@@ -41,6 +98,69 @@ Device setup is done entirely through the Home Assistant UI.
    - **Domain** *(Optional)*: SIP Domain/Realm (defaults to Server).
    - **Caller ID** *(Optional)*: Caller display name.
    - **RTP Port** *(Optional)*: Base local RTP port for audio stream (default: `7078`).
+   - **Outbound proxy** *(Optional)*: Use when the registrar answers `407 Proxy Authentication Required` (see [generic SIP / ITSP](#pbx-compatibility)).
+   - **Authentication username** *(Optional)*: Digest username when it differs from the extension.
+
+---
+
+## PBX compatibility
+
+This repository does **not** mark a PBX as "supported" unless a version was recorded from a real test. The table is the honest status as of the last documentation pass.
+
+| PBX | Status | Recorded version | Notes |
+|-----|--------|------------------|-------|
+| **FreePBX** (Asterisk **pjsip**) | Recommended settings published | — | Primary target for the Quick Start. No lab version is checked in here, so this is not a certification. |
+| **Asterisk** (pjsip, no FreePBX) | Same endpoint settings | — | Use the `pjsip` snippet below. |
+| **3CX** (including SBC) | Community reported | — | Inbound via SBC needed Record-Route on 200 OK ([#39](https://github.com/eigger/hass-sip/issues/39)). Core now preserves Record-Route; no 3CX version is recorded here. |
+| **Generic SIP / ITSP / UniFi Talk** | Unverified | — | Outbound `407 Proxy Authentication Required` ([#17](https://github.com/eigger/hass-sip/issues/17)): set **Outbound proxy** to the proxy host and **Authentication username** if it differs from the extension. |
+
+SIP **TLS** and **SRTP** are out of scope (UDP signalling only).
+
+### Recommended pjsip endpoint values
+
+Use these whether you click through FreePBX or edit `pjsip.conf`. They match what the client actually implements.
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| Transport | UDP `5060` | Only SIP/2.0/UDP is implemented |
+| Codecs | `g722`, `ulaw` (`PCMU`), `alaw` (`PCMA`) | Offer order is G.722 → PCMU → PCMA |
+| DTMF | RFC 4733 (`telephone-event`) | RTP events plus SIP INFO (`application/dtmf-relay`) |
+| `direct_media` | `no` | Avoids a media hairpin re-INVITE; set `yes` only if you need it and audio stays up |
+| `rtp_symmetric` / `force_rport` / `rewrite_contact` | `yes` | NAT; the client also latches the RTP source address |
+| Session timers (RFC 4028) | off / not required | No `Supported: timer` / `Session-Expires` |
+| Media encryption | none | No SRTP |
+| `qualify` | `yes` | OPTIONS keep-alive is fine |
+
+Standalone Asterisk example:
+
+```ini
+[1001]
+type=endpoint
+context=from-internal
+disallow=all
+allow=g722,ulaw,alaw
+direct_media=no
+rtp_symmetric=yes
+force_rport=yes
+rewrite_contact=yes
+dtmf_mode=rfc4733
+media_encryption=no
+timers=no
+auth=1001
+aors=1001
+transport=transport-udp
+
+[1001]
+type=auth
+auth_type=userpass
+username=1001
+password=change-me
+
+[1001]
+type=aor
+max_contacts=1
+remove_existing=yes
+```
 
 ---
 
@@ -699,8 +819,8 @@ action:
 
 ## Troubleshooting
 
-- **Registration fails**: Double-check the SIP extension credentials and host IP address. Ensure your firewall or FreePBX settings permit UDP traffic on port `5060` from the Home Assistant host.
-- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Ensure the RTP port range (defaults starting at `7078`) is open and routed properly. After a call, check **Call Audio** (`no_rx` means we sent but heard nothing) and **Bidirectional Audio**; the phone-line media player also shows `call_duration`, byte counts, and `audio_path`. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** for SDP vs latched addresses. Passwords are redacted; phone numbers are masked.
+- **Registration fails**: Double-check the SIP extension credentials and host IP address. Ensure your firewall or FreePBX settings permit UDP traffic on port `5060` from the Home Assistant host. Follow the [Quick start](#quick-start-freepbx) and [recommended pjsip values](#recommended-pjsip-endpoint-values). A `423` from the registrar is handled by raising the register expiration; a `407` on outbound calls usually means you need an outbound proxy.
+- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Set `direct_media=no`, open the RTP port range (defaults starting at `7078`), and confirm **Call Audio** (`no_rx` means we sent but heard nothing). The phone-line media player also shows `call_duration`, byte counts, and `audio_path`. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** for SDP vs latched addresses. Passwords are redacted; phone numbers are masked.
 - **FFmpeg errors**: Ensure that the `ffmpeg` system binary is installed and accessible in your Home Assistant path, as it is utilized for audio transcoding.
 - **SIP / RTP protocol trace**: Off by default. To capture signalling (INVITE / 200 OK / REGISTER) and a 5-second RTP summary without putting digest credentials in the log, add this to `configuration.yaml` and restart:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then on the extension:
 4. **Codecs**: enable `g722`, `ulaw`, and `alaw` (order does not have to match; hass-sip offers G.722, then PCMU, then PCMA).
 5. **Submit** and **Apply Config**.
 
-Allow **UDP 5060** from the Home Assistant host to the PBX, and **UDP RTP** from Home Assistant (default starting at `7078`, plus the next even port for RTCP).
+Allow **UDP 5060** from the Home Assistant host to the PBX, and **UDP `local_rtp_port`** (default `7078`) for RTP. The client binds that one port only; **RTCP is not used**, so do not open or debug the next odd/even port.
 
 ### 2. Add the integration
 
@@ -70,7 +70,7 @@ Wait a few seconds. The **Registration status** sensor should read `registered`,
 
 ### 4. Place a test call
 
-From another phone on the PBX, dial `1001`. Answer with `sip.answer` (or enable auto-answer for that caller in `sip_contacts.json`). You should get two-way audio; the media player **Call Audio** attribute should become `bidirectional`.
+From another phone on the PBX, dial `1001`. Answer with `sip.answer` (or enable auto-answer for that caller in `sip_contacts.json`). You should get two-way audio; the **Call Audio** sensor (and the media player's `audio_path` attribute) should become `bidirectional`.
 
 To dial out from Home Assistant:
 
@@ -820,7 +820,7 @@ action:
 ## Troubleshooting
 
 - **Registration fails**: Double-check the SIP extension credentials and host IP address. Ensure your firewall or FreePBX settings permit UDP traffic on port `5060` from the Home Assistant host. Follow the [Quick start](#quick-start-freepbx) and [recommended pjsip values](#recommended-pjsip-endpoint-values). A `423` from the registrar is handled by raising the register expiration; a `407` on outbound calls usually means you need an outbound proxy.
-- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Set `direct_media=no`, open the RTP port range (defaults starting at `7078`), and confirm **Call Audio** (`no_rx` means we sent but heard nothing). The phone-line media player also shows `call_duration`, byte counts, and `audio_path`. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** for SDP vs latched addresses. Passwords are redacted; phone numbers are masked.
+- **No Audio / One-way Audio**: This is typically caused by NAT or routing issues. Set `direct_media=no`, open UDP `local_rtp_port` (default `7078`; RTCP is not used), and confirm the **Call Audio** sensor (`audio_path`; `no_rx` means we sent but heard nothing). The phone-line media player also exposes `call_duration`, byte counts, and `audio_path`. Download diagnostics from **Settings → Devices & Services → SIP Client → ⋮ → Download diagnostics** for SDP vs latched addresses. Passwords are redacted; phone numbers are masked.
 - **FFmpeg errors**: Ensure that the `ffmpeg` system binary is installed and accessible in your Home Assistant path, as it is utilized for audio transcoding.
 - **SIP / RTP protocol trace**: Off by default. To capture signalling (INVITE / 200 OK / REGISTER) and a 5-second RTP summary without putting digest credentials in the log, add this to `configuration.yaml` and restart:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -845,29 +845,23 @@ reconfigure 첫 화면과 검증 실패 후 재시도 모두 비밀번호를 넣
 
 ## P5 — 호환성 문서 + 포지셔닝
 
-### [ ] P5-1. PBX 호환성 표 + 검증된 설정 예제 (P0와 병행 권장)
+### [x] P5-1. PBX 호환성 표 + 검증된 설정 예제 (P0와 병행 권장)
 
-**근거** 외부 이슈 5건 중 3건이 PBX 설정/변종 문제. 현재 README는
-"FreePBX, Asterisk, or any VoIP provider"라고 쓰는데 3CX에서 이미 이슈가 났다.
+**근거** 외부 이슈 5건 중 3건이 PBX 설정/변종 문제. README가 "any VoIP provider"를
+지원처럼 읽히게 했다.
 
 **작업**
-1. **실제로 테스트한 PBX만 "지원"으로 표기한다.** 나머지는 `커뮤니티 보고` /
-   `미검증`으로 구분한다. 최소 표 형태:
-
-   | PBX | 상태 | 검증 버전 | 비고 |
-   |---|---|---|---|
-   | Asterisk (pjsip) | 지원 / 미검증 | | `direct_media` 설정 명시 |
-   | FreePBX | 지원 / 미검증 | | 내선 생성 절차 |
-   | 3CX | 커뮤니티 보고 | | 이슈 #39 (SBC Record-Route) |
-   | Generic SIP / 사업자 트렁크 | 미검증 | | 이슈 #17 (407) |
-
-2. FreePBX·Asterisk 각각에 대해 **검증된 설정값**을 명시한다:
-   `direct_media`, DTMF 모드(RFC 2833 vs INFO), Session Timer, 코덱 순서(G.722/G.711),
-   NAT 관련 설정. 이 목록 자체가 안정성 문서 역할을 한다.
-3. 30초 Quick Start: 내선 생성 → 통합 추가 → 등록 확인 → 내선으로 전화.
+1. README에 호환성 표를 넣었다. 이 저장소에 랩 버전이 없으므로 어떤 PBX도
+   "지원"으로 표기하지 않았다. FreePBX/Asterisk는 권장 설정, 3CX는 커뮤니티
+   보고(#39), 일반 ITSP는 미검증(#17 407).
+2. FreePBX·Asterisk pjsip에 `direct_media=no`, DTMF RFC 4733, 코덱
+   G.722/PCMU/PCMA, 세션 타이머 끄기, NAT rewrite를 명시했다.
+3. Quick Start: FreePBX 내선 생성 → 통합 추가 → Registration sensor → 시험 통화.
 
 **수용 기준** 신규 사용자가 README만 보고 FreePBX 내선을 만들어 등록까지 도달할 수 있다.
 검증되지 않은 PBX가 "지원"으로 표기되어 있지 않다.
+
+**추가된 테스트** 없음 (문서 카드).
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a FreePBX Quick Start (create pjsip extension → add the integration → confirm `registered` → test call) so a new user can register from the README alone.
- Add a PBX compatibility table that does **not** label any system as "supported": FreePBX/Asterisk have recommended pjsip settings (no lab version recorded), 3CX is community reported (#39), generic ITSP/UniFi Talk is unverified (#17 `407`).
- Soften the intro so it no longer reads as "any VoIP provider". Document UDP-only, codecs, DTMF RFC 4733, `direct_media=no`, and session timers off.

## Test plan
- [x] `python -m pytest tests/` (266 passed)
- [x] `ruff check custom_components/ tests/`
- [ ] Follow the Quick Start against a LAN FreePBX pjsip extension and confirm the Registration status sensor becomes `registered`
- [ ] Confirm the compatibility table does not use "supported" for an unverified PBX


Made with [Cursor](https://cursor.com)