### PR TITLE
ci: install Home Assistant at the hacs.json minimum

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install pytest voluptuous "homeassistant>=2026.8.0"
+          HA_MIN=$(python -c "import json; print(json.load(open('hacs.json'))['homeassistant'])")
+          pip install pytest voluptuous "homeassistant>=${HA_MIN}"
           if [ -f custom_components/sip/manifest.json ]; then
             python -c "import json; reqs = json.load(open('custom_components/sip/manifest.json')).get('requirements', []); print('\n'.join(reqs))" > requirements.txt
             if [ -s requirements.txt ]; then

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,8 @@
 - SIP core에는 `homeassistant` import 금지. 새 기능이 HA를 필요로 하면 콜백/주입으로 뺀다.
 - 이벤트 루프에서 블로킹 I/O 금지(파일, 소켓, subprocess 대기).
 - 로그에 크리덴셜, `Authorization` 헤더 값, digest response를 절대 남기지 않는다.
-- `ruff check custom_components/` 통과. CI는 Python 3.14, `homeassistant>=2026.8.0`.
+- `ruff check custom_components/` 통과. CI는 Python 3.14, Home Assistant 최솟값은
+  `hacs.json` (`homeassistant`, 현재 `2026.9.0`).
 - 사용자에게 보이는 동작이 바뀌면 `strings.json` + `translations/{en,ko,de,ru}.json`을
   함께 갱신한다.
 


### PR DESCRIPTION
## Summary
- Test CI now installs `homeassistant>=` the version in `hacs.json` (currently 2026.9.0) instead of a stale 2026.8.0 pin.
- ROADMAP work-principles line matches that single source of truth.

## Test plan
- [ ] Tests workflow installs Home Assistant 2026.9.x (or newer)
- [ ] Changing `hacs.json` `homeassistant` without touching the workflow still updates the CI floor