### PR TITLE
fix: use a valid MDI icon for the negotiated codec sensor

### DIFF
--- a/custom_components/sip/sensor.py
+++ b/custom_components/sip/sensor.py
@@ -198,7 +198,7 @@ class _SipMediaSensor(SensorEntity):
 class SipCodecSensor(_SipMediaSensor):
     """Negotiated audio codec of the current / last call."""
 
-    _attr_icon = "mdi:codec"
+    _attr_icon = "mdi:waveform"
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_options = list(CODEC_OPTIONS)
 


### PR DESCRIPTION
## Summary
- The negotiated codec sensor used `mdi:codec`, which is not a Material Design Icons name, so the entity rendered with no icon.
- Switch to `mdi:waveform`.

## Test plan
- [ ] After reload/upgrade, the Negotiated Codec sensor shows a waveform icon in the UI


Made with [Cursor](https://cursor.com)