### PR TITLE
docs: restore the Home Assistant usage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/eigger/hass-sip?style=flat-square)](https://github.com/eigger/hass-sip/releases)
 [![License](https://img.shields.io/github/license/eigger/hass-sip?style=flat-square)](LICENSE)
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
+![integration usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=usage&suffix=%20installs&cacheSeconds=15600&query=%24.sip.total&url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json)
 
 hass-sip **registers as a SIP extension** on your PBX. It exposes the line as a media player, sends and receives DTMF, runs IVR menus, records calls, and can bridge a call to Home Assistant Voice Assist.
 


### PR DESCRIPTION
## Summary
- Put the dynamic HA analytics usage badge back on the README (`query=$.sip.total`).
- The domain is still absent from the feed today, so the badge may render empty until installs are counted.

## Test plan
- [ ] README shows the usage badge next to Release / License / HACS
- [ ] When `sip` appears in `custom_integrations.json`, the badge shows the install count


Made with [Cursor](https://cursor.com)